### PR TITLE
Fix performance issues by using an action cache

### DIFF
--- a/ChaCha/ChaCha.cs
+++ b/ChaCha/ChaCha.cs
@@ -358,7 +358,7 @@ namespace Cryptool.Plugins.ChaCha
             uint[] originalState = (uint[])(state.Clone());
             DispatchToPresentation(delegate
             {
-                _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, state);
+                _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, (uint[])(state.Clone()));
             });
             for (int i = 0; i < settings.Rounds / 2; ++i)
             {
@@ -369,7 +369,7 @@ namespace Cryptool.Plugins.ChaCha
                 state = QuarterroundState(state, 3, 7, 11, 15);
                 DispatchToPresentation(delegate
                 {
-                    _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, state);
+                    _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, (uint[])(state.Clone()));
                 });
                 // diagonal round
                 state = QuarterroundState(state, 0, 5, 10, 15);
@@ -378,7 +378,7 @@ namespace Cryptool.Plugins.ChaCha
                 state = QuarterroundState(state, 3, 4, 9, 14);
                 DispatchToPresentation(delegate
                 {
-                    _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, state);
+                    _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, (uint[])(state.Clone()));
                 });
             }
             // add the original state

--- a/ChaCha/ChaCha.cs
+++ b/ChaCha/ChaCha.cs
@@ -356,6 +356,10 @@ namespace Cryptool.Plugins.ChaCha
         public uint[] ChaChaHash(uint[] state)
         {
             uint[] originalState = (uint[])(state.Clone());
+            DispatchToPresentation(delegate
+            {
+                _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, state);
+            });
             for (int i = 0; i < settings.Rounds / 2; ++i)
             {
                 // column round
@@ -363,11 +367,19 @@ namespace Cryptool.Plugins.ChaCha
                 state = QuarterroundState(state, 1, 5, 9, 13);
                 state = QuarterroundState(state, 2, 6, 10, 14);
                 state = QuarterroundState(state, 3, 7, 11, 15);
+                DispatchToPresentation(delegate
+                {
+                    _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, state);
+                });
                 // diagonal round
                 state = QuarterroundState(state, 0, 5, 10, 15);
                 state = QuarterroundState(state, 1, 6, 11, 12);
                 state = QuarterroundState(state, 2, 7, 8, 13);
                 state = QuarterroundState(state, 3, 4, 9, 14);
+                DispatchToPresentation(delegate
+                {
+                    _presentation.AddResult(ResultType.CHACHA_HASH_ROUND, state);
+                });
             }
             // add the original state
             for (int i = 0; i < state.Length; ++i)

--- a/ChaCha/ChaCha.cs
+++ b/ChaCha/ChaCha.cs
@@ -448,6 +448,13 @@ namespace Cryptool.Plugins.ChaCha
             (c, d, b) = quarterroundStep(c, d, b, 12);
             (a, b, d) = quarterroundStep(a, b, d, 8);
             (c, d, b) = quarterroundStep(c, d, b, 7);
+            DispatchToPresentation(delegate
+            {
+                _presentation.AddResult(ResultType.QR_OUTPUT_A, a);
+                _presentation.AddResult(ResultType.QR_OUTPUT_B, b);
+                _presentation.AddResult(ResultType.QR_OUTPUT_C, c);
+                _presentation.AddResult(ResultType.QR_OUTPUT_D, d);
+            });
             return (a, b, c, d);
         }
 

--- a/ChaCha/ChaCha.csproj
+++ b/ChaCha/ChaCha.csproj
@@ -83,8 +83,11 @@
     </Compile>
     <Compile Include="ChaChaSettings.cs" />
     <Compile Include="Visualization\IntermediateResultsManager.cs" />
+    <Compile Include="Visualization\Navigation\ActionCache.cs" />
+    <Compile Include="Visualization\Navigation\IActionCache.cs" />
     <Compile Include="Visualization\Navigation\Navigation.cs" />
     <Compile Include="Visualization\Navigation\IActionNavigation.cs" />
+    <Compile Include="Visualization\Pages\CachePageAction.cs" />
     <Compile Include="Visualization\Pages\KeystreamBlockGenPage.cs" />
     <Compile Include="Visualization\Pages\LandingPage.cs" />
     <Compile Include="Visualization\Pages\Page.cs" />

--- a/ChaCha/Visualization/ChaChaPresentation.xaml
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml
@@ -1083,7 +1083,7 @@
                              Canvas.Top="20" Canvas.Left="10"
                              FontSize="10"
                              TextAlignment="Center" Foreground="{ Binding ElementName=ShiftCircle_4, Path=Stroke}"
-                             Text="8"/>
+                             Text="7"/>
                         </Canvas>
                         <Canvas Grid.Row="1" Grid.Column="4">
                           <Border Name="QRXORCell_4" Width="65" Height="20" BorderBrush="Black" BorderThickness="1,1,1,1" Canvas.Top="22">

--- a/ChaCha/Visualization/ChaChaPresentation.xaml
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml
@@ -25,10 +25,6 @@
     </Style>
 
     <!-- (Rich)TextBox styles -->
-    <Style TargetType="TextBox">
-      <Setter Property="IsReadOnly" Value="True"/>
-      <Setter Property="BorderThickness" Value="0"/>
-    </Style>
     <Style x:Key="hexTextBox" TargetType="TextBox">
       <Setter Property="FontFamily" Value="Courier New" />
       <Setter Property="IsReadOnly" Value="True"/>
@@ -78,6 +74,12 @@
   <Grid Name="UIContentPane">
       <!-- Landing page -->
     <ContentControl Name="UILandingPage" Visibility="Collapsed" Template="{ StaticResource PageTemplate }">
+      <ContentControl.Resources>
+        <Style TargetType="TextBox">
+          <Setter Property="IsReadOnly" Value="True"/>
+          <Setter Property="BorderThickness" Value="0"/>
+        </Style>
+      </ContentControl.Resources>
       <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
         <TextBox Margin="10" FontSize="24" HorizontalAlignment="Center">
           ChaCha Visualization
@@ -89,6 +91,12 @@
     </ContentControl>
     <!-- ChaCha workflow page -->
     <ContentControl Name="UIWorkflowPage" Visibility="Collapsed" Template="{ StaticResource PageTemplate }">
+      <ContentControl.Resources>
+        <Style TargetType="TextBox">
+          <Setter Property="IsReadOnly" Value="True"/>
+          <Setter Property="BorderThickness" Value="0"/>
+        </Style>
+      </ContentControl.Resources>
       <Grid>
         <Grid.RowDefinitions>
           <RowDefinition Style="{ StaticResource title }" />
@@ -138,6 +146,12 @@
     <!-- ChaCha State matrix page -->
     <ContentControl Name="UIStateMatrixPage" Visibility="Collapsed" Template="{ StaticResource PageTemplate }">
       <Grid>
+        <Grid.Resources>
+          <Style TargetType="TextBox">
+            <Setter Property="IsReadOnly" Value="True"/>
+            <Setter Property="BorderThickness" Value="0"/>
+          </Style>
+        </Grid.Resources>
         <Grid.RowDefinitions>
           <RowDefinition Style="{ StaticResource title }" />
           <RowDefinition />
@@ -334,6 +348,12 @@
     <!-- ChaCha Generate Keystream block page -->
     <ContentControl Name="UIKeystreamBlockGenPage" Visibility="Visible" Template="{ StaticResource PageTemplate }">
       <Grid>
+        <Grid.Resources>
+          <Style TargetType="TextBox">
+            <Setter Property="IsReadOnly" Value="True"/>
+            <Setter Property="BorderThickness" Value="0"/>
+          </Style>
+        </Grid.Resources>
         <Grid.RowDefinitions>
           <RowDefinition Style="{ StaticResource title }" />
           <RowDefinition />

--- a/ChaCha/Visualization/ChaChaPresentation.xaml.cs
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml.cs
@@ -11,10 +11,12 @@ namespace Cryptool.Plugins.ChaCha
     [PluginBase.Attributes.Localization("Cryptool.Plugins.ChaCha.Properties.Resources")]
     public partial class ChaChaPresentation : UserControl, INotifyPropertyChanged
     {
-        private readonly IntermediateResultsManager intermediateResultsManager;
+        private readonly IntermediateResultsManager<uint> uint_resultsManager;
+        private readonly IntermediateResultsManager<uint[]> uint_array_resultsManager;
         public ChaChaPresentation()
         {
-            intermediateResultsManager = new IntermediateResultsManager();
+            uint_resultsManager = new IntermediateResultsManager<uint>();
+            uint_array_resultsManager = new IntermediateResultsManager<uint[]>();
             InitializeComponent();
             InitVisualization();
             DataContext = this;
@@ -195,17 +197,26 @@ namespace Cryptool.Plugins.ChaCha
         #endregion
 
         #region IntermediateResultsManager API
-        public void AddResult(ResultType type, object result)
+        public void AddResult(ResultType<uint> type, uint result)
         {
-            intermediateResultsManager.AddResult(type, (uint)result);
+            uint_resultsManager.AddResult(type, result);
         }
-        public string GetHexResult(ResultType type, int index)
+        public string GetHexResult(ResultType<uint> type, int index)
         {
-            return HexString(intermediateResultsManager.Get(type, index));
+            return HexString(uint_resultsManager.Get(type, index));
+        }
+        public void AddResult(ResultType<uint[]> type, uint[] result)
+        {
+            uint_array_resultsManager.AddResult(type, result);
+        }
+        public string GetHexResult(ResultType<uint[]> type, int i, int j)
+        {
+            return HexString(uint_array_resultsManager.Get(type, i)[j]);
         }
         public void ClearResults()
         {
-            intermediateResultsManager.Clear();
+            uint_resultsManager.Clear();
+            uint_array_resultsManager.Clear();
         }
         #endregion
 

--- a/ChaCha/Visualization/ChaChaPresentation.xaml.cs
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml.cs
@@ -13,10 +13,12 @@ namespace Cryptool.Plugins.ChaCha
     {
         private readonly IntermediateResultsManager<uint> uint_resultsManager;
         private readonly IntermediateResultsManager<uint[]> uint_array_resultsManager;
+        private readonly ActionCache cache;
         public ChaChaPresentation()
         {
             uint_resultsManager = new IntermediateResultsManager<uint>();
             uint_array_resultsManager = new IntermediateResultsManager<uint[]>();
+            cache = new ActionCache(this);
             InitializeComponent();
             InitVisualization();
             DataContext = this;

--- a/ChaCha/Visualization/ChaChaPresentation.xaml.cs
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml.cs
@@ -13,12 +13,10 @@ namespace Cryptool.Plugins.ChaCha
     {
         private readonly IntermediateResultsManager<uint> uint_resultsManager;
         private readonly IntermediateResultsManager<uint[]> uint_array_resultsManager;
-        private readonly ActionCache cache;
         public ChaChaPresentation()
         {
             uint_resultsManager = new IntermediateResultsManager<uint>();
             uint_array_resultsManager = new IntermediateResultsManager<uint[]>();
-            cache = new ActionCache(this);
             InitializeComponent();
             InitVisualization();
             DataContext = this;

--- a/ChaCha/Visualization/ChaChaPresentation.xaml.cs
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml.cs
@@ -213,6 +213,10 @@ namespace Cryptool.Plugins.ChaCha
         {
             return HexString(uint_array_resultsManager.Get(type, i)[j]);
         }
+        public uint[] GetResult(ResultType<uint[]> type, int index)
+        {
+            return uint_array_resultsManager.Get(type, index);
+        }
         public void ClearResults()
         {
             uint_resultsManager.Clear();

--- a/ChaCha/Visualization/IntermediateResultsManager.cs
+++ b/ChaCha/Visualization/IntermediateResultsManager.cs
@@ -3,31 +3,43 @@ using System.Collections.Generic;
 
 namespace Cryptool.Plugins.ChaCha
 {
-    public enum ResultType
+    public class ResultType
     {
-        QR_INPUT_A, QR_INPUT_B, QR_INPUT_C, QR_INPUT_D,
-        QR_INPUT_X1, QR_INPUT_X2, QR_INPUT_X3,
-        QR_OUTPUT_X1, QR_OUTPUT_X2, QR_OUTPUT_X3,
-        QR_ADD_X1_X2, QR_XOR
+        public static readonly ResultType<uint> QR_INPUT_A = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_INPUT_B = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_INPUT_C = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_INPUT_D = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_INPUT_X1 = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_INPUT_X2 = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_INPUT_X3 = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_OUTPUT_X1 = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_OUTPUT_X2 = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_OUTPUT_X3 = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_ADD_X1_X2 = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_XOR = new ResultType<uint>();
+        public static readonly ResultType<uint[]> CHACHA_HASH_ROUND = new ResultType<uint[]>();
     }
-    public class IntermediateResultsManager
+    public class ResultType<T> { }
+    public class IntermediateResultsManager<T>
     {
        
-        private class InterimResultList
+        private class IntermediateResultsList
         {
-            private readonly List<uint> _results;
+            private readonly List<T> _results;
+            private ResultType<T> type;
 
-            public InterimResultList(ResultType type)
+            public IntermediateResultsList(ResultType<T> type)
             {
-                _results = new List<uint>();
+                _results = new List<T>();
                 Type = type;
             }
-            public ResultType Type { get; }
-            public uint Get(int index)
+
+            public ResultType<T> Type { get; }
+            public T Get(int index)
             {
                 return _results[index];
             }
-            public void Add(uint result)
+            public void Add(T result)
             {
                 _results.Add(result);
             }
@@ -36,38 +48,38 @@ namespace Cryptool.Plugins.ChaCha
                 _results.Clear();
             }
         }
-        private readonly List<InterimResultList> _interimResultsList = new List<InterimResultList>();
-        private bool TypeExists(ResultType type)
+        private readonly List<IntermediateResultsList> _intermediateResultsList = new List<IntermediateResultsList>();
+        private bool TypeExists(ResultType<T> type)
         {
-            return _interimResultsList.Exists(list => list.Type == type);
+            return _intermediateResultsList.Exists(list => list.Type == type);
         }
-        private InterimResultList GetList(ResultType type)
+        private IntermediateResultsList GetList(ResultType<T> type)
         {
             if (!TypeExists(type))
             {
                 return null;
             }
-            return _interimResultsList.Find(list => list.Type == type);
+            return _intermediateResultsList.Find(list => list.Type == type);
         }
         public void Clear()
         {
-            foreach (InterimResultList r in _interimResultsList)
+            foreach (IntermediateResultsList r in _intermediateResultsList)
             {
                 r.Clear();
             }
-            _interimResultsList.Clear();
         }
-        public void AddResult(ResultType type, uint result)
+        public void AddResult(ResultType<T> type, T result)
         {
             if (!TypeExists(type))
             {
-                _interimResultsList.Add(new InterimResultList(type));
+                _intermediateResultsList.Add(new IntermediateResultsList(type));
             }
             GetList(type).Add(result);
         }
-        public uint Get(ResultType type, int index)
+
+        public T Get(ResultType<T> type, int index)
         {
-            InterimResultList list = GetList(type);
+            IntermediateResultsList list = GetList(type);
             if (list == null)
             {
                 throw new ArgumentException(string.Format("InterimResultList of type {0}, index {1} does not exist", type.ToString(), index));

--- a/ChaCha/Visualization/IntermediateResultsManager.cs
+++ b/ChaCha/Visualization/IntermediateResultsManager.cs
@@ -17,6 +17,10 @@ namespace Cryptool.Plugins.ChaCha
         public static readonly ResultType<uint> QR_OUTPUT_X3 = new ResultType<uint>();
         public static readonly ResultType<uint> QR_ADD_X1_X2 = new ResultType<uint>();
         public static readonly ResultType<uint> QR_XOR = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_OUTPUT_A = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_OUTPUT_B = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_OUTPUT_C = new ResultType<uint>();
+        public static readonly ResultType<uint> QR_OUTPUT_D = new ResultType<uint>();
         public static readonly ResultType<uint[]> CHACHA_HASH_ROUND = new ResultType<uint[]>();
     }
     public class ResultType<T> { }

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+
+namespace Cryptool.Plugins.ChaCha
+{
+    class ActionCache : IActionCache
+    {
+        private Dictionary<int, CachePageAction> _cache;
+        private ChaChaPresentation _pres;
+        public ActionCache(ChaChaPresentation pres)
+        {
+            _pres = pres;
+            _cache = GetCache();
+        }
+        public CachePageAction Get(int actionIndex)
+        {
+            return _cache[actionIndex];
+        }
+
+        public bool Includes(int actionIndex)
+        {
+            return _cache.ContainsKey(actionIndex);
+        }
+
+        public void Set(CachePageAction pageAction, int actionIndex)
+        {
+            _cache[actionIndex] = pageAction;
+        }
+
+        public static Dictionary<int, CachePageAction> GetCache()
+        {
+            // TODO init cache
+            return null;
+        }
+    }
+}

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Windows.Controls;
 
@@ -35,6 +36,7 @@ namespace Cryptool.Plugins.ChaCha
             cache238.Add(KeystreamBlockGenPage.ClearQRDetail(pres));
             cache238.AddToExec(() =>
             {
+                // update state matrix
                 TextBox[] stateTextBoxes = KeystreamBlockGenPage.GetStateTextBoxes(pres);
                 uint[] round2State = pres.GetResult(ResultType.CHACHA_HASH_ROUND, 1);
                 Debug.Assert(stateTextBoxes.Length == round2State.Length);
@@ -42,6 +44,11 @@ namespace Cryptool.Plugins.ChaCha
                 {
                     stateTextBoxes[i].Text = ChaChaPresentation.HexString(round2State[i]);
                 }
+                // update round indicator
+                pres.CurrentRoundIndex = 2;
+                pres.Nav.Replace(pres.CurrentRound, "2");
+                // hide all QR arrows except the first
+                KeystreamBlockGenPage.HideAllQRArrowsExcept(pres, 1);
             });
             return new Dictionary<int, CachePageAction>{{ 238, cache238 }};
         }

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -33,9 +33,9 @@ namespace Cryptool.Plugins.ChaCha
         {
             // Cache entry for action index: 283 - "Round 2"
             CachePageAction cache283 = new CachePageAction();
-            cache283.AddToExec(() => KeystreamBlockGenPage.ClearQRDetail(pres));
             cache283.AddToExec(() =>
             {
+                KeystreamBlockGenPage.ClearQRDetail(pres);
                 // update state matrix
                 TextBox[] stateTextBoxes = KeystreamBlockGenPage.GetStateTextBoxes(pres);
                 uint[] round2State = pres.GetResult(ResultType.CHACHA_HASH_ROUND, 1);

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -46,7 +46,7 @@ namespace Cryptool.Plugins.ChaCha
                         stateTextBoxes[x].Text = ChaChaPresentation.HexString(round2State[x]);
                     }
                     // highlight only diagonal state entries because they will be copied into QR detail in next action
-                    (int i, int j, int k, int l) = KeystreamBlockGenPage.GetStateIndices(round);
+                    (int i, int j, int k, int l) = round % 2 == 1 ? (0, 4, 8, 12) : (0, 5, 10, 15);
                     KeystreamBlockGenPage.UnmarkAllStateEntriesExcept(pres, i, j, k, l);
                     // update round indicator
                     pres.CurrentRoundIndex = round;

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -31,28 +31,95 @@ namespace Cryptool.Plugins.ChaCha
 
         public static Dictionary<int, CachePageAction> GetCache(ChaChaPresentation pres)
         {
-            // Cache entry for action index: 283 - "Round 2"
-            CachePageAction cache283 = new CachePageAction();
-            cache283.AddToExec(() =>
+            CachePageAction GenerateRoundCacheEntry(int round)
             {
-                KeystreamBlockGenPage.ClearQRDetail(pres);
-                // update state matrix
-                TextBox[] stateTextBoxes = KeystreamBlockGenPage.GetStateTextBoxes(pres);
-                uint[] round2State = pres.GetResult(ResultType.CHACHA_HASH_ROUND, 1);
-                Debug.Assert(stateTextBoxes.Length == round2State.Length);
-                for (int i = 0; i < round2State.Length; ++i)
+                CachePageAction cache = new CachePageAction();
+                cache.AddToExec(() =>
                 {
-                    stateTextBoxes[i].Text = ChaChaPresentation.HexString(round2State[i]);
-                }
-                // highlight only diagonal state entries because they will be copied into QR detail in next action
-                KeystreamBlockGenPage.UnmarkAllStateEntriesExcept(pres, 0, 5, 10, 15);
-                // update round indicator
-                pres.CurrentRoundIndex = 2;
-                pres.Nav.Replace(pres.CurrentRound, "2");
-                // hide all QR arrows except the fifth
-                KeystreamBlockGenPage.HideAllQRArrowsExcept(pres, 5);
-            });
-            return new Dictionary<int, CachePageAction>{{ 283, cache283 } };
+                    KeystreamBlockGenPage.ClearQRDetail(pres);
+                    // update state matrix
+                    TextBox[] stateTextBoxes = KeystreamBlockGenPage.GetStateTextBoxes(pres);
+                    uint[] round2State = pres.GetResult(ResultType.CHACHA_HASH_ROUND, round - 1);
+                    Debug.Assert(stateTextBoxes.Length == round2State.Length);
+                    for (int x = 0; x < round2State.Length; ++x)
+                    {
+                        stateTextBoxes[x].Text = ChaChaPresentation.HexString(round2State[x]);
+                    }
+                    // highlight only diagonal state entries because they will be copied into QR detail in next action
+                    (int i, int j, int k, int l) = KeystreamBlockGenPage.GetStateIndices(round);
+                    KeystreamBlockGenPage.UnmarkAllStateEntriesExcept(pres, i, j, k, l);
+                    // update round indicator
+                    pres.CurrentRoundIndex = round;
+                    pres.Nav.Replace(pres.CurrentRound, round.ToString());
+                    // hide all QR arrows except the one for the round
+                    int qrIndex = round % 2 == 1 ? 1 : 5;
+                    KeystreamBlockGenPage.HideAllQRArrowsExcept(pres, qrIndex);
+                });
+                return cache;
+            }
+            // Cache entry for action index: 3 - "Round 1"
+            CachePageAction cache3 = GenerateRoundCacheEntry(1);
+            // Cache entry for action index: 283 - "Round 2"
+            CachePageAction cache283 = GenerateRoundCacheEntry(2);
+            // Cache entry for action index: 563 - "Round 3"
+            CachePageAction cache563 = GenerateRoundCacheEntry(3);
+            // Cache entry for action index: 843 - "Round 4"
+            CachePageAction cache843 = GenerateRoundCacheEntry(4);
+            // Cache entry for action index: 1123 - "Round 5"
+            CachePageAction cache1123 = GenerateRoundCacheEntry(5);
+            // Cache entry for action index: 1403 - "Round 6"
+            CachePageAction cache1403 = GenerateRoundCacheEntry(6);
+            // Cache entry for action index: 1683 - "Round 7"
+            CachePageAction cache1683 = GenerateRoundCacheEntry(7);
+            // Cache entry for action index: 1963 - "Round 8"
+            CachePageAction cache1963 = GenerateRoundCacheEntry(8);
+            // Cache entry for action index: 2243 - "Round 9"
+            CachePageAction cache2243 = GenerateRoundCacheEntry(9);
+            // Cache entry for action index: 2523 - "Round 10"
+            CachePageAction cache2523 = GenerateRoundCacheEntry(10);
+            // Cache entry for action index: 2803 - "Round 11"
+            CachePageAction cache2803 = GenerateRoundCacheEntry(11);
+            // Cache entry for action index: 3083 - "Round 12"
+            CachePageAction cache3083 = GenerateRoundCacheEntry(12);
+            // Cache entry for action index: 3363 - "Round 13"
+            CachePageAction cache3363 = GenerateRoundCacheEntry(13);
+            // Cache entry for action index: 3643 - "Round 14"
+            CachePageAction cache3643 = GenerateRoundCacheEntry(14);
+            // Cache entry for action index: 3923 - "Round 15"
+            CachePageAction cache3923 = GenerateRoundCacheEntry(15);
+            // Cache entry for action index: 4203 - "Round 16"
+            CachePageAction cache4203 = GenerateRoundCacheEntry(16);
+            // Cache entry for action index: 4483 - "Round 17"
+            CachePageAction cache4483 = GenerateRoundCacheEntry(17);
+            // Cache entry for action index: 4763 - "Round 18"
+            CachePageAction cache4763 = GenerateRoundCacheEntry(18);
+            // Cache entry for action index: 5043 - "Round 19"
+            CachePageAction cache5043 = GenerateRoundCacheEntry(19);
+            // Cache entry for action index: 5323 - "Round 20"
+            CachePageAction cache5323 = GenerateRoundCacheEntry(20);
+            return new Dictionary<int, CachePageAction>
+            {
+                { 3, cache3 },
+                { 283, cache283 },
+                { 563, cache563 },
+                { 843, cache843 },
+                { 1123, cache1123 },
+                { 1403, cache1403 },
+                { 1683, cache1683 },
+                { 1963, cache1963 },
+                { 2243, cache2243 },
+                { 2523, cache2523 },
+                { 2803, cache2803 },
+                { 3083, cache3083 },
+                { 3363, cache3363 },
+                { 3643, cache3643 },
+                { 3923, cache3923 },
+                { 4203, cache4203 },
+                { 4483, cache4483 },
+                { 4763, cache4763 },
+                { 5043, cache5043 },
+                { 5323, cache5323 }
+            };
         }
     }
 }

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -33,7 +33,7 @@ namespace Cryptool.Plugins.ChaCha
         {
             // Cache entry for action index: 238 - "Round 2"
             CachePageAction cache238 = new CachePageAction();
-            cache238.Add(KeystreamBlockGenPage.ClearQRDetail(pres));
+            cache238.AddToExec(() => KeystreamBlockGenPage.ClearQRDetail(pres));
             cache238.AddToExec(() =>
             {
                 // update state matrix

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -44,6 +44,8 @@ namespace Cryptool.Plugins.ChaCha
                 {
                     stateTextBoxes[i].Text = ChaChaPresentation.HexString(round2State[i]);
                 }
+                // highlight only diagonal state entries because they will be copied into QR detail in next action
+                KeystreamBlockGenPage.UnmarkAllStateEntriesExcept(pres, 0, 5, 10, 15);
                 // update round indicator
                 pres.CurrentRoundIndex = 2;
                 pres.Nav.Replace(pres.CurrentRound, "2");

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -47,8 +47,8 @@ namespace Cryptool.Plugins.ChaCha
                 // update round indicator
                 pres.CurrentRoundIndex = 2;
                 pres.Nav.Replace(pres.CurrentRound, "2");
-                // hide all QR arrows except the first
-                KeystreamBlockGenPage.HideAllQRArrowsExcept(pres, 1);
+                // hide all QR arrows except the fifth
+                KeystreamBlockGenPage.HideAllQRArrowsExcept(pres, 5);
             });
             return new Dictionary<int, CachePageAction>{{ 283, cache283 } };
         }

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
+using System.Windows.Controls;
 
 namespace Cryptool.Plugins.ChaCha
 {
@@ -9,7 +11,7 @@ namespace Cryptool.Plugins.ChaCha
         public ActionCache(ChaChaPresentation pres)
         {
             _pres = pres;
-            _cache = GetCache();
+            _cache = GetCache(pres);
         }
         public CachePageAction Get(int actionIndex)
         {
@@ -26,10 +28,22 @@ namespace Cryptool.Plugins.ChaCha
             _cache[actionIndex] = pageAction;
         }
 
-        public static Dictionary<int, CachePageAction> GetCache()
+        public static Dictionary<int, CachePageAction> GetCache(ChaChaPresentation pres)
         {
-            // TODO init cache
-            return null;
+            // Cache entry for action index: 238 - "Round 2"
+            CachePageAction cache238 = new CachePageAction();
+            cache238.Add(KeystreamBlockGenPage.ClearQRDetail(pres));
+            cache238.AddToExec(() =>
+            {
+                TextBox[] stateTextBoxes = KeystreamBlockGenPage.GetStateTextBoxes(pres);
+                uint[] round2State = pres.GetResult(ResultType.CHACHA_HASH_ROUND, 1);
+                Debug.Assert(stateTextBoxes.Length == round2State.Length);
+                for (int i = 0; i < round2State.Length; ++i)
+                {
+                    stateTextBoxes[i].Text = ChaChaPresentation.HexString(round2State[i]);
+                }
+            });
+            return new Dictionary<int, CachePageAction>{{ 238, cache238 }};
         }
     }
 }

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -31,10 +31,10 @@ namespace Cryptool.Plugins.ChaCha
 
         public static Dictionary<int, CachePageAction> GetCache(ChaChaPresentation pres)
         {
-            // Cache entry for action index: 238 - "Round 2"
-            CachePageAction cache238 = new CachePageAction();
-            cache238.AddToExec(() => KeystreamBlockGenPage.ClearQRDetail(pres));
-            cache238.AddToExec(() =>
+            // Cache entry for action index: 283 - "Round 2"
+            CachePageAction cache283 = new CachePageAction();
+            cache283.AddToExec(() => KeystreamBlockGenPage.ClearQRDetail(pres));
+            cache283.AddToExec(() =>
             {
                 // update state matrix
                 TextBox[] stateTextBoxes = KeystreamBlockGenPage.GetStateTextBoxes(pres);
@@ -50,7 +50,7 @@ namespace Cryptool.Plugins.ChaCha
                 // hide all QR arrows except the first
                 KeystreamBlockGenPage.HideAllQRArrowsExcept(pres, 1);
             });
-            return new Dictionary<int, CachePageAction>{{ 238, cache238 }};
+            return new Dictionary<int, CachePageAction>{{ 283, cache283 } };
         }
     }
 }

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -1,18 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.Windows.Controls;
+using System.Linq;
 
 namespace Cryptool.Plugins.ChaCha
 {
     class ActionCache : IActionCache
     {
+        public static readonly ActionCache Empty = new ActionCache(new Dictionary<int, CachePageAction>());
         private Dictionary<int, CachePageAction> _cache;
-        private ChaChaPresentation _pres;
-        public ActionCache(ChaChaPresentation pres)
+        public ActionCache(Dictionary<int, CachePageAction> cache)
         {
-            _pres = pres;
-            _cache = GetCache(pres);
+            _cache = cache;
+        }
+        public bool NotEmpty
+        {
+            get
+            {
+                return _cache.Keys.Count != 0;
+            }
         }
         public CachePageAction Get(int actionIndex)
         {
@@ -29,97 +34,9 @@ namespace Cryptool.Plugins.ChaCha
             _cache[actionIndex] = pageAction;
         }
 
-        public static Dictionary<int, CachePageAction> GetCache(ChaChaPresentation pres)
+        public int GetClosestCache(int n)
         {
-            CachePageAction GenerateRoundCacheEntry(int round)
-            {
-                CachePageAction cache = new CachePageAction();
-                cache.AddToExec(() =>
-                {
-                    KeystreamBlockGenPage.ClearQRDetail(pres);
-                    // update state matrix
-                    TextBox[] stateTextBoxes = KeystreamBlockGenPage.GetStateTextBoxes(pres);
-                    uint[] stateEntries = pres.GetResult(ResultType.CHACHA_HASH_ROUND, round - 1);
-                    Debug.Assert(stateTextBoxes.Length == stateEntries.Length);
-                    for (int x = 0; x < stateEntries.Length; ++x)
-                    {
-                        stateTextBoxes[x].Text = ChaChaPresentation.HexString(stateEntries[x]);
-                    }
-                    // highlight only diagonal state entries because they will be copied into QR detail in next action
-                    (int i, int j, int k, int l) = round % 2 == 1 ? (0, 4, 8, 12) : (0, 5, 10, 15);
-                    KeystreamBlockGenPage.UnmarkAllStateEntriesExcept(pres, i, j, k, l);
-                    // update round indicator
-                    pres.CurrentRoundIndex = round;
-                    pres.Nav.Replace(pres.CurrentRound, round.ToString());
-                    // hide all QR arrows except the one for the round
-                    int qrIndex = round % 2 == 1 ? 1 : 5;
-                    KeystreamBlockGenPage.HideAllQRArrowsExcept(pres, qrIndex);
-                });
-                return cache;
-            }
-            // Cache entry for action index: 3 - "Round 1"
-            CachePageAction cache3 = GenerateRoundCacheEntry(1);
-            // Cache entry for action index: 283 - "Round 2"
-            CachePageAction cache283 = GenerateRoundCacheEntry(2);
-            // Cache entry for action index: 563 - "Round 3"
-            CachePageAction cache563 = GenerateRoundCacheEntry(3);
-            // Cache entry for action index: 843 - "Round 4"
-            CachePageAction cache843 = GenerateRoundCacheEntry(4);
-            // Cache entry for action index: 1123 - "Round 5"
-            CachePageAction cache1123 = GenerateRoundCacheEntry(5);
-            // Cache entry for action index: 1403 - "Round 6"
-            CachePageAction cache1403 = GenerateRoundCacheEntry(6);
-            // Cache entry for action index: 1683 - "Round 7"
-            CachePageAction cache1683 = GenerateRoundCacheEntry(7);
-            // Cache entry for action index: 1963 - "Round 8"
-            CachePageAction cache1963 = GenerateRoundCacheEntry(8);
-            // Cache entry for action index: 2243 - "Round 9"
-            CachePageAction cache2243 = GenerateRoundCacheEntry(9);
-            // Cache entry for action index: 2523 - "Round 10"
-            CachePageAction cache2523 = GenerateRoundCacheEntry(10);
-            // Cache entry for action index: 2803 - "Round 11"
-            CachePageAction cache2803 = GenerateRoundCacheEntry(11);
-            // Cache entry for action index: 3083 - "Round 12"
-            CachePageAction cache3083 = GenerateRoundCacheEntry(12);
-            // Cache entry for action index: 3363 - "Round 13"
-            CachePageAction cache3363 = GenerateRoundCacheEntry(13);
-            // Cache entry for action index: 3643 - "Round 14"
-            CachePageAction cache3643 = GenerateRoundCacheEntry(14);
-            // Cache entry for action index: 3923 - "Round 15"
-            CachePageAction cache3923 = GenerateRoundCacheEntry(15);
-            // Cache entry for action index: 4203 - "Round 16"
-            CachePageAction cache4203 = GenerateRoundCacheEntry(16);
-            // Cache entry for action index: 4483 - "Round 17"
-            CachePageAction cache4483 = GenerateRoundCacheEntry(17);
-            // Cache entry for action index: 4763 - "Round 18"
-            CachePageAction cache4763 = GenerateRoundCacheEntry(18);
-            // Cache entry for action index: 5043 - "Round 19"
-            CachePageAction cache5043 = GenerateRoundCacheEntry(19);
-            // Cache entry for action index: 5323 - "Round 20"
-            CachePageAction cache5323 = GenerateRoundCacheEntry(20);
-            return new Dictionary<int, CachePageAction>
-            {
-                { 3, cache3 },
-                { 283, cache283 },
-                { 563, cache563 },
-                { 843, cache843 },
-                { 1123, cache1123 },
-                { 1403, cache1403 },
-                { 1683, cache1683 },
-                { 1963, cache1963 },
-                { 2243, cache2243 },
-                { 2523, cache2523 },
-                { 2803, cache2803 },
-                { 3083, cache3083 },
-                { 3363, cache3363 },
-                { 3643, cache3643 },
-                { 3923, cache3923 },
-                { 4203, cache4203 },
-                { 4483, cache4483 },
-                { 4763, cache4763 },
-                { 5043, cache5043 },
-                { 5323, cache5323 }
-            };
+            return _cache.Keys.ToArray().OrderBy(x => Math.Abs(x - n)).First();
         }
     }
 }

--- a/ChaCha/Visualization/Navigation/ActionCache.cs
+++ b/ChaCha/Visualization/Navigation/ActionCache.cs
@@ -39,11 +39,11 @@ namespace Cryptool.Plugins.ChaCha
                     KeystreamBlockGenPage.ClearQRDetail(pres);
                     // update state matrix
                     TextBox[] stateTextBoxes = KeystreamBlockGenPage.GetStateTextBoxes(pres);
-                    uint[] round2State = pres.GetResult(ResultType.CHACHA_HASH_ROUND, round - 1);
-                    Debug.Assert(stateTextBoxes.Length == round2State.Length);
-                    for (int x = 0; x < round2State.Length; ++x)
+                    uint[] stateEntries = pres.GetResult(ResultType.CHACHA_HASH_ROUND, round - 1);
+                    Debug.Assert(stateTextBoxes.Length == stateEntries.Length);
+                    for (int x = 0; x < stateEntries.Length; ++x)
                     {
-                        stateTextBoxes[x].Text = ChaChaPresentation.HexString(round2State[x]);
+                        stateTextBoxes[x].Text = ChaChaPresentation.HexString(stateEntries[x]);
                     }
                     // highlight only diagonal state entries because they will be copied into QR detail in next action
                     (int i, int j, int k, int l) = round % 2 == 1 ? (0, 4, 8, 12) : (0, 5, 10, 15);

--- a/ChaCha/Visualization/Navigation/ActionNavigation.cs
+++ b/ChaCha/Visualization/Navigation/ActionNavigation.cs
@@ -11,16 +11,19 @@ namespace Cryptool.Plugins.ChaCha
 {
     public class ActionNavigation : IActionNavigation<TextBlock, Border, Shape, RichTextBox, TextBox>
     {
-        public bool SaveStateHasBeenCalled { get; private set; } = false;
-
         private readonly Brush _copyBrush = Brushes.AliceBlue;
         private readonly Brush _markBrush = Brushes.Purple;
 
         #region Interface implementation
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
+        public bool SaveStateHasBeenCalled { get; private set; } = false;
         // Stack with actions where the last dictionary contains undo actions which reverts changes from the last applied page action of an UI Element.
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         private readonly Stack<Dictionary<int, Action>> _undoState = new Stack<Dictionary<int, Action>>();
         // temporary variable to collect undo actions before pushing into stack.
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         private readonly Dictionary<int, Action> _undoActions = new Dictionary<int, Action>();
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         public void SaveState(params TextBlock[] textblocks)
         {
             SaveStateHasBeenCalled = true;
@@ -44,6 +47,7 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         public void SaveState(params Border[] borders)
         {
             SaveStateHasBeenCalled = true;
@@ -89,6 +93,7 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         public void SaveState(params Shape[] shapes)
         {
             SaveStateHasBeenCalled = true;
@@ -116,6 +121,7 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         public void SaveState(params RichTextBox[] textboxes)
         {
             SaveStateHasBeenCalled = true;
@@ -136,6 +142,7 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         public void SaveState(params TextBox[] textboxes)
         {
             SaveStateHasBeenCalled = true;
@@ -151,6 +158,7 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         public void FinishPageAction()
         {
             // copy dictionary using new
@@ -159,11 +167,13 @@ namespace Cryptool.Plugins.ChaCha
             SaveStateHasBeenCalled = false;
         }
 
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         public Dictionary<int, Action> GetUndoActions()
         {
             return _undoState.Pop();
         }
 
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         public void Undo()
         {
             Dictionary<int, Action> undoActions = GetUndoActions();
@@ -233,35 +243,29 @@ namespace Cryptool.Plugins.ChaCha
         #region TextBlock API
         public void RemoveLast(TextBlock tb)
         {
-            SaveState(tb);
             _RemoveLast(tb.Inlines);
         }
         public void ReplaceLast(TextBlock tb, Inline element)
         {
-            SaveState(tb);
             _ReplaceLast(tb.Inlines, element);
         }
         public void ReplaceLast(TextBlock tb, string text)
         {
-            SaveState(tb);
             _ReplaceLast(tb.Inlines, new Run(text));
         }
         public void MakeBoldLast(TextBlock tb)
         {
-            SaveState(tb);
             _MakeBoldLast(tb.Inlines);
         }
         public void UnboldLast(params TextBlock[] tbs)
         {
             foreach (TextBlock tb in tbs)
             {
-                SaveState(tb);
                 _UnboldLast(tb.Inlines);
             }
         }
         public void Add(TextBlock tb, Inline element)
         {
-            SaveState(tb);
             _Add(tb.Inlines, element);
         }
         public void Add(TextBlock tb, string element)
@@ -276,7 +280,6 @@ namespace Cryptool.Plugins.ChaCha
         {
             foreach (TextBlock tb in textblocks)
             {
-                SaveState(tb);
                 _Clear(tb.Inlines);
             }
         }
@@ -285,7 +288,6 @@ namespace Cryptool.Plugins.ChaCha
         #region Border API
         public void SetBackground(Border b, Brush background)
         {
-            SaveState(b);
             b.Background = background;
         }
         public void SetCopyBackground(Border b)
@@ -298,12 +300,10 @@ namespace Cryptool.Plugins.ChaCha
         }
         public void SetBorderColor(Border b, Brush borderBrush)
         {
-            SaveState(b);
             b.BorderBrush = borderBrush;
         }
         public void SetBorderStroke(Border b, double stroke)
         {
-            SaveState(b);
             b.BorderThickness = new Thickness(stroke);
         }
         public void MarkBorder(Border b)
@@ -447,12 +447,10 @@ namespace Cryptool.Plugins.ChaCha
         #region Shape API
         public void SetShapeStrokeColor(Shape s, Brush brush)
         {
-            SaveState(s);
             s.Stroke = brush;
         }
         public void SetShapeStroke(Shape s, double stroke)
         {
-            SaveState(s);
             s.StrokeThickness = stroke;
         }
         public void MarkShape(Shape s)
@@ -472,13 +470,11 @@ namespace Cryptool.Plugins.ChaCha
         {
             foreach (RichTextBox rtb in rtbs)
             {
-                SaveState(rtb);
                 _UnboldLast(rtb.Document.Blocks);
             }
         }
         public void Add(RichTextBox tb, Inline element)
         {
-            SaveState(tb);
             _Add(tb.Document.Blocks, element);
         }
         public void Add(RichTextBox tb, string text)
@@ -493,7 +489,6 @@ namespace Cryptool.Plugins.ChaCha
         {
             foreach (RichTextBox tb in tbs)
             {
-                SaveState(tb);
                 _Clear(tb.Document.Blocks);
             }
         }
@@ -507,7 +502,6 @@ namespace Cryptool.Plugins.ChaCha
         #region TextBox API
         public void Replace(TextBox tb, string text)
         {
-            SaveState(tb);
             tb.Text = text;
         }
 
@@ -515,7 +509,6 @@ namespace Cryptool.Plugins.ChaCha
         {
             foreach (TextBox tb in tbs)
             {
-                SaveState(tb);
                 tb.Text = "";
             }
         }

--- a/ChaCha/Visualization/Navigation/ActionNavigation.cs
+++ b/ChaCha/Visualization/Navigation/ActionNavigation.cs
@@ -340,6 +340,8 @@ namespace Cryptool.Plugins.ChaCha
 
         public PageAction CopyAction(Border[] copyFrom, Border[] copyTo, string[] previousToValue, bool replace = false)
         {
+            Debug.Assert(copyTo.Length == copyFrom.Length, $"Amount of copyTo ({copyTo.Length}) and copyFrom elements ({copyFrom.Length}) not equal");
+            Debug.Assert(copyTo.Length == previousToValue.Length, $"Amount of copyTo ({copyTo.Length}) and previousToValue elements ({previousToValue.Length}) not equal");
             return new PageAction(() =>
             {
                 for (int i = 0; i < copyTo.Length; ++i)

--- a/ChaCha/Visualization/Navigation/ActionNavigation.cs
+++ b/ChaCha/Visualization/Navigation/ActionNavigation.cs
@@ -298,9 +298,12 @@ namespace Cryptool.Plugins.ChaCha
         {
             SetBackground(b, _copyBrush);
         }
-        public void UnsetBackground(Border b)
+        public void UnsetBackground(params Border[] borders)
         {
-            SetBackground(b, Brushes.White);
+            foreach(Border b in borders)
+            {
+                SetBackground(b, Brushes.White);
+            }
         }
         public void SetBorderColor(Border b, Brush borderBrush)
         {

--- a/ChaCha/Visualization/Navigation/ActionNavigation.cs
+++ b/ChaCha/Visualization/Navigation/ActionNavigation.cs
@@ -380,7 +380,7 @@ namespace Cryptool.Plugins.ChaCha
                     {
                         if (replace)
                         {
-                            Replace(copyToRichTextBox, text);
+                            ReplaceLast(copyToRichTextBox, text);
                         }
                         else
                         {
@@ -410,7 +410,7 @@ namespace Cryptool.Plugins.ChaCha
                     }
                     else if (copyToBorder.Child is RichTextBox copyFromRichTextBox)
                     {
-                        Replace(copyFromRichTextBox, text);
+                        ReplaceLast(copyFromRichTextBox, text);
                     }
                     else if (copyToBorder.Child is TextBox copyFromTextBox)
                     {
@@ -525,6 +525,10 @@ namespace Cryptool.Plugins.ChaCha
         {
             _RemoveLast(tb.Document.Blocks);
         }
+        public void ReplaceLast(RichTextBox tb, string text)
+        {
+            _ReplaceLast(tb.Document.Blocks, new Run(text));
+        }
         public void Add(RichTextBox tb, Inline element)
         {
             _Add(tb.Document.Blocks, element);
@@ -544,7 +548,7 @@ namespace Cryptool.Plugins.ChaCha
                 _Clear(tb.Document.Blocks);
             }
         }
-        public void Replace(RichTextBox rtb, string text)
+        public void Clear(RichTextBox rtb, string text)
         {
             _Clear(rtb.Document.Blocks);
             Add(rtb, text);

--- a/ChaCha/Visualization/Navigation/IActionCache.cs
+++ b/ChaCha/Visualization/Navigation/IActionCache.cs
@@ -1,0 +1,23 @@
+﻿namespace Cryptool.Plugins.ChaCha
+{
+    /**
+     * Interface for page action caches.
+     */
+    interface IActionCache
+    {
+        /**
+         * Check if action at actionIndex is included in this cache.
+         */
+        bool Includes(int actionIndex);
+
+        /**
+         * Get the page action for this action index if it exists.
+         */
+        CachePageAction Get(int actionIndex);
+
+        /**
+         * Cache PageAction with this action index, linking them together.
+         */
+        void Set(CachePageAction pageAction, int actionIndex);
+    }
+}

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -490,7 +490,6 @@ namespace Cryptool.Plugins.ChaCha
         {
             int relative = n - CurrentActionIndex;
             // if (relative != 0) Console.WriteLine($"MoveToAction({n}) - CurrentActionIndex: {CurrentActionIndex}, relative: {relative}");
-            // TODO check if action is cached
             if (relative != 0 && cache.Includes(n))
             {
                 ExecuteCache(n);

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -518,7 +518,14 @@ namespace Cryptool.Plugins.ChaCha
                             _moveToActionIndicesStack.Clear();
                         }
                     }
+                    var watch = System.Diagnostics.Stopwatch.StartNew();
                     this.Dispatcher.Invoke(() => MoveToAction(n));
+                    watch.Stop();
+                    var elapsedMs = watch.ElapsedMilliseconds;
+                    if (elapsedMs != 0)
+                    {
+                        Console.WriteLine($"'MoveToAction({n})' took {elapsedMs} ms");
+                    }
                 }, cancellationToken);
             }
             while (true)

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -117,8 +117,7 @@ namespace Cryptool.Plugins.ChaCha
 
                 try
                 {
-                    if (((string)value).Length > 0)
-                        input = int.Parse((String)value);
+                    input = int.Parse((String)value);
                 }
                 catch (Exception e)
                 {

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -452,9 +452,11 @@ namespace Cryptool.Plugins.ChaCha
         private readonly Stack<int> _moveToActionIndicesStack = new Stack<int>();
         private void MoveToActionAsync(int n)
         {
+            // Console.WriteLine($"MoveToActionAsync({n})");
             lock (_moveToActionIndicesStack)
             {
                 _moveToActionIndicesStack.Push(n);
+                // Console.WriteLine($"Pushed {n} onto action stack.");
             }
         }
 
@@ -470,9 +472,12 @@ namespace Cryptool.Plugins.ChaCha
         }
         private void ExecuteCache(int n)
         {
+            // Console.WriteLine($"ExecuteCache({n})");
             cache.Get(n).Exec();
             CurrentActionIndex = n;
+            // Console.WriteLine($"CurrentActionIndex = {n}");
             _moveToActionIndicesStack.Clear();
+            // Console.WriteLine("Cleared action stack");
         }
         /**
          * Move to Action with given index.
@@ -483,8 +488,9 @@ namespace Cryptool.Plugins.ChaCha
         private void MoveToAction(int n)
         {
             int relative = n - CurrentActionIndex;
+            // Console.WriteLine($"MoveToAction({n}) - CurrentActionIndex: {CurrentActionIndex}, relative: {relative}");
             // TODO check if action is cached
-            if(cache.Includes(n))
+            if (cache.Includes(n))
             {
                 ExecuteCache(n);
             }
@@ -532,6 +538,7 @@ namespace Cryptool.Plugins.ChaCha
                         {
                             n = _moveToActionIndicesStack.Pop();
                             _moveToActionIndicesStack.Clear();
+                            // Console.WriteLine($"Popped {n} from action stack and cleared stack");
                         }
                     }
                     var watch = System.Diagnostics.Stopwatch.StartNew();
@@ -540,7 +547,7 @@ namespace Cryptool.Plugins.ChaCha
                     var elapsedMs = watch.ElapsedMilliseconds;
                     if (elapsedMs != 0)
                     {
-                        Console.WriteLine($"'MoveToAction({n})' took {elapsedMs} ms");
+                        // Console.WriteLine($"'MoveToAction({n})' took {elapsedMs} ms");
                     }
                 }, cancellationToken);
             }

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -307,23 +307,11 @@ namespace Cryptool.Plugins.ChaCha
 
         public bool NavigationEnabled => InputValid && ExecutionFinished;
 
-        private void PrevAction_Click(object sender, RoutedEventArgs e)
-        {
-            CurrentActionIndex--;
-            CurrentPage.Actions[CurrentActionIndex].Undo();
-        }
-
-        private void NextAction_Click(object sender, RoutedEventArgs e)
-        {
-            WrapExecWithNavigation(CurrentPage.Actions[CurrentActionIndex]);
-            CurrentActionIndex++;
-        }
-
         private Button PrevButton()
         {
             Button b = CreateNavigationButton();
             b.SetBinding(Button.IsEnabledProperty, new Binding("PrevActionIsEnabled"));
-            b.Click += PrevAction_Click;
+            b.Click += (sender, e) => MoveActions(-1);
             b.Content = "<";
             return b;
         }
@@ -332,18 +320,14 @@ namespace Cryptool.Plugins.ChaCha
         {
             Button b = CreateNavigationButton();
             b.SetBinding(Button.IsEnabledProperty, new Binding("NextActionIsEnabled"));
-            b.Click += NextAction_Click;
+            b.Click += (sender, e) => MoveActions(1);
             b.Content = ">";
             return b;
         }
 
         private void ResetPageActions()
         {
-            for (int i = CurrentActionIndex; i > 0; i--)
-            {
-                // this undo's the page actions on each action click
-                PrevAction_Click(null, null);
-            }
+            MoveToAction(0);
             Debug.Assert(CurrentActionIndex == 0);
             // Dont forget to also undo init actions.
             // Reverse because order (may) matter. Undoing should be done in a FIFO queue!
@@ -355,18 +339,29 @@ namespace Cryptool.Plugins.ChaCha
 
         private void MoveActions(int n)
         {
+            void PrevActionClick(object sender, RoutedEventArgs e)
+            {
+                CurrentActionIndex--;
+                CurrentPage.Actions[CurrentActionIndex].Undo();
+            }
+
+            void NextActionClick(object sender, RoutedEventArgs e)
+            {
+                WrapExecWithNavigation(CurrentPage.Actions[CurrentActionIndex]);
+                CurrentActionIndex++;
+            }
             if (n < 0)
             {
                 for (int i = 0; i < Math.Abs(n); ++i)
                 {
-                    PrevAction_Click(null, null);
+                    PrevActionClick(null, null);
                 }
             }
             else
             {
                 for (int i = 0; i < Math.Abs(n); ++i)
                 {
-                    NextAction_Click(null, null);
+                    NextActionClick(null, null);
                 }
             }
         }

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -463,6 +463,12 @@ namespace Cryptool.Plugins.ChaCha
             WrapExecWithNavigation(CurrentPage.Actions[CurrentActionIndex]);
             CurrentActionIndex++;
         }
+        private void ExecuteCache(int n)
+        {
+            cache.Get(n).Exec();
+            CurrentActionIndex = n;
+            _moveToActionIndicesStack.Clear();
+        }
         /**
          * Move to Action with given index.
          *
@@ -473,7 +479,11 @@ namespace Cryptool.Plugins.ChaCha
         {
             int relative = n - CurrentActionIndex;
             // TODO check if action is cached
-            if (relative < 0)
+            if(cache.Includes(n))
+            {
+                ExecuteCache(n);
+            }
+            else if (relative < 0)
             {
                 for (int i = 0; i < Math.Abs(relative); ++i)
                 {

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -93,7 +93,8 @@ namespace Cryptool.Plugins.ChaCha
             s.AutoToolTipPlacement = AutoToolTipPlacement.BottomRight;
             void S_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
             {
-                MoveToActionAsync((int)s.Value);
+                int value = (int) s.Value;
+                if(CurrentActionIndex != value) MoveToActionAsync(value);
             };
             s.ValueChanged += S_ValueChanged;
             s.VerticalAlignment = VerticalAlignment.Center;

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -77,30 +77,37 @@ namespace Cryptool.Plugins.ChaCha
                 pageNavBar.Children.Add(CreatePageNavigationButton(i));
             }
         }
-        private void InitActionSliderNavigationBar(StackPanel actionNavBar, int totalActions)
-        {
 
-            actionNavBar.Children.Clear();
-            Slider s = new Slider();
-            s.Minimum = 0;
-            s.Maximum = totalActions;
-            // TODO set width dynamically depending on total actions
-            s.Width = 1000;
-            s.TickFrequency = 1;
-            s.TickPlacement = TickPlacement.None;
-            s.IsSnapToTickEnabled = true;
+        private Slider CreateActionNavigationSlider(int totalActions)
+        {
+            Slider s = new Slider
+            {
+                Minimum = 0,
+                Maximum = totalActions,
+                // TODO set width dynamically depending on total actions
+                Width = 1000,
+                TickFrequency = 1,
+                TickPlacement = TickPlacement.None,
+                IsSnapToTickEnabled = true,
+                VerticalAlignment = VerticalAlignment.Center,
+                AutoToolTipPlacement = AutoToolTipPlacement.BottomRight
+            };
+            
             s.SetBinding(Slider.ValueProperty, new Binding("CurrentActionIndex") { Mode = BindingMode.OneWay });
-            s.AutoToolTipPlacement = AutoToolTipPlacement.BottomRight;
             void S_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
             {
-                int value = (int) s.Value;
-                if(CurrentActionIndex != value) MoveToActionAsync(value);
+                int value = (int)s.Value;
+                if (CurrentActionIndex != value) MoveToActionAsync(value);
             };
             s.ValueChanged += S_ValueChanged;
-            s.VerticalAlignment = VerticalAlignment.Center;
+            return s;
+        }
+
+        private TextBox CreateCurrentActionIndexTextBox()
+        {
             TextBox current = new TextBox { VerticalAlignment = VerticalAlignment.Center, Width = 30 };
             current.SetBinding(TextBox.TextProperty,
-                new Binding("CurrentActionIndexTextBox") { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged});
+                new Binding("CurrentActionIndexTextBox") { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged });
 
             void HandleKeyDown(object sender, KeyEventArgs e)
             {
@@ -116,10 +123,17 @@ namespace Cryptool.Plugins.ChaCha
             }
 
             current.KeyDown += HandleKeyDown;
+            return current;
+        }
+        private void InitActionSliderNavigationBar(StackPanel actionNavBar, int totalActions)
+        {
+            actionNavBar.Children.Clear();
+            Slider actionSlider = CreateActionNavigationSlider(totalActions);
+            TextBox current = CreateCurrentActionIndexTextBox();
             TextBlock delimiter = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = "/" };
             TextBlock total = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = totalActions.ToString() };
             actionNavBar.Children.Add(PrevButton());
-            actionNavBar.Children.Add(s);
+            actionNavBar.Children.Add(actionSlider);
             Button next = NextButton();
             next.Margin = new Thickness(1, 0, 3, 0);
             actionNavBar.Children.Add(next);

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -98,7 +98,8 @@ namespace Cryptool.Plugins.ChaCha
             s.ValueChanged += S_ValueChanged;
             s.VerticalAlignment = VerticalAlignment.Center;
             TextBox current = new TextBox { VerticalAlignment = VerticalAlignment.Center, Width = 30 };
-            current.SetBinding(TextBox.TextProperty, new Binding("CurrentActionIndex") { Mode = BindingMode.TwoWay });
+            current.SetBinding(TextBox.TextProperty,
+                new Binding("CurrentActionIndex_") { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged});
             TextBlock delimiter = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = "/" };
             TextBlock total = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = totalActions.ToString() };
             actionNavBar.Children.Add(PrevButton());
@@ -262,11 +263,22 @@ namespace Cryptool.Plugins.ChaCha
             {
                 _currentActionIndex = value;
                 OnPropertyChanged("CurrentActionIndex");
+                OnPropertyChanged("CurrentActionIndex_");
                 OnPropertyChanged("CurrentActions");
                 OnPropertyChanged("NextActionIsEnabled");
                 OnPropertyChanged("PrevActionIsEnabled");
                 OnPropertyChanged("NextRoundIsEnabled");
                 OnPropertyChanged("PrevRoundIsEnabled");
+            }
+        }
+
+        public int CurrentActionIndex_
+        {
+            get => _currentActionIndex;
+            set
+            {
+                Console.WriteLine($"Set CurrentActionIndex to ${value} from TextBox");
+                MoveToActionAsync(value);
             }
         }
 

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -475,11 +475,20 @@ namespace Cryptool.Plugins.ChaCha
         private void ExecuteCache(int n)
         {
             // Console.WriteLine($"ExecuteCache({n})");
-            cache.Get(n).Exec();
+            Cache.Get(n).Exec();
             CurrentActionIndex = n;
             _moveToActionIndicesStack.Clear();
             // Console.WriteLine("Cleared action stack");
         }
+
+        private ActionCache Cache
+        {
+            get
+            {
+                return CurrentPage.Cache;
+            }
+        }
+
         /**
          * Move to Action with given index.
          *
@@ -492,11 +501,23 @@ namespace Cryptool.Plugins.ChaCha
             // if (relative != 0) Console.WriteLine($"MoveToAction({n}) - CurrentActionIndex: {CurrentActionIndex}, relative: {relative}");
             // TODO Implement "relative caching"
             //   (go first to nearest cache entry in constant time and then from there to destination index)
-            if (relative != 0 && cache.Includes(n))
+            if (relative != 0)
             {
-                ExecuteCache(n);
+                if(Cache.NotEmpty)
+                {
+                    int closestCache = Cache.GetClosestCache(n);
+                    int distanceCacheToDestination = Math.Abs(closestCache - n);
+                    // Console.WriteLine($"closestCache: {closestCache}, distanceCacheToDestination: {distanceCacheToDestination}");
+                    if (distanceCacheToDestination < Math.Abs(relative))
+                    {
+                        ExecuteCache(closestCache);
+                        relative = n - closestCache;
+                        // Console.WriteLine($"new relative: {relative}");
+                    }
+                    // Console.WriteLine($"closestCache: {closestCache}, n: {n}, relative: {relative}");
+                }
             }
-            else if (relative < 0)
+            if (relative < 0)
             {
                 for (int i = 0; i < Math.Abs(relative); ++i)
                 {

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -385,6 +385,12 @@ namespace Cryptool.Plugins.ChaCha
             WrapExecWithNavigation(CurrentPage.Actions[CurrentActionIndex]);
             CurrentActionIndex++;
         }
+        /**
+         * Move to Action with given index.
+         *
+         * Implements action navigation with absolute value.
+         * Action is immediately executed.
+         */
         private void MoveToAction(int n)
         {
             int relative = n - CurrentActionIndex;

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -337,6 +337,11 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
+        /**
+         * Move n actions back / forward.
+         *
+         * Implements action navigation with relative value.
+         */
         private void MoveActions(int n)
         {
             void PrevActionClick(object sender, RoutedEventArgs e)
@@ -366,6 +371,11 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
+        /**
+         * Move to Action with given index.
+         *
+         * Implements action navigation with absolute value.
+         */
         private void MoveToAction(int n)
         {
             MoveActions(n - CurrentActionIndex);

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -472,6 +472,7 @@ namespace Cryptool.Plugins.ChaCha
         private void MoveToAction(int n)
         {
             int relative = n - CurrentActionIndex;
+            // TODO check if action is cached
             if (relative < 0)
             {
                 for (int i = 0; i < Math.Abs(relative); ++i)

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -394,9 +394,6 @@ namespace Cryptool.Plugins.ChaCha
         private void MoveToAction(int n)
         {
             int relative = n - CurrentActionIndex;
-            if (relative != 0)
-            {
-            }
             if (relative < 0)
             {
                 for (int i = 0; i < Math.Abs(relative); ++i)

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -97,8 +97,13 @@ namespace Cryptool.Plugins.ChaCha
             s.SetBinding(Slider.ValueProperty, new Binding("CurrentActionIndex") { Mode = BindingMode.OneWay });
             void S_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
             {
-                int value = (int)s.Value;
-                if (CurrentActionIndex != value) MoveToActionAsync(value);
+                // Only execute listener logic if value changed by user
+                if(s.IsFocused)
+                {
+                    int value = (int)s.Value;
+                    // Console.WriteLine($"Slider value changed to {value}");
+                    if (CurrentActionIndex != value) MoveToActionAsync(value);
+                }
             };
             s.ValueChanged += S_ValueChanged;
             return s;

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -329,7 +329,7 @@ namespace Cryptool.Plugins.ChaCha
         {
             MoveToAction(0);
             Debug.Assert(CurrentActionIndex == 0);
-            // Dont forget to also undo init actions.
+            // Also undo init actions.
             // Reverse because order (may) matter. Undoing should be done in a FIFO queue!
             foreach (PageAction pageAction in CurrentPage.InitActions.Reverse())
             {

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -333,7 +333,7 @@ namespace Cryptool.Plugins.ChaCha
             set
             {
                 _currentActionIndex = value;
-                // Console.WriteLine($"CurrentActionIndex = {n}");
+                // Console.WriteLine($"CurrentActionIndex = {value}");
                 CurrentActionIndexTextBox = value;
                 OnPropertyChanged("CurrentActionIndex");
                 OnPropertyChanged("CurrentActions");

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -490,6 +490,8 @@ namespace Cryptool.Plugins.ChaCha
         {
             int relative = n - CurrentActionIndex;
             // if (relative != 0) Console.WriteLine($"MoveToAction({n}) - CurrentActionIndex: {CurrentActionIndex}, relative: {relative}");
+            // TODO Implement "relative caching"
+            //   (go first to nearest cache entry in constant time and then from there to destination index)
             if (relative != 0 && cache.Includes(n))
             {
                 ExecuteCache(n);

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -255,7 +255,6 @@ namespace Cryptool.Plugins.ChaCha
                 OnPropertyChanged("PrevActionIsEnabled");
                 OnPropertyChanged("NextRoundIsEnabled");
                 OnPropertyChanged("PrevRoundIsEnabled");
-                //InitActionNavigationBar(CurrentPage);
             }
         }
 

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -81,7 +81,6 @@ namespace Cryptool.Plugins.ChaCha
 
             actionNavBar.Children.Clear();
             Slider s = new Slider();
-            Binding currentActionIndexBinding = new Binding("CurrentActionIndex") { Mode = BindingMode.OneWay };
             s.Minimum = 0;
             s.Maximum = totalActions;
             // TODO set width dynamically depending on total actions
@@ -89,7 +88,7 @@ namespace Cryptool.Plugins.ChaCha
             s.TickFrequency = 1;
             s.TickPlacement = TickPlacement.None;
             s.IsSnapToTickEnabled = true;
-            s.SetBinding(Slider.ValueProperty, currentActionIndexBinding);
+            s.SetBinding(Slider.ValueProperty, new Binding("CurrentActionIndex") { Mode = BindingMode.OneWay });
             s.AutoToolTipPlacement = AutoToolTipPlacement.BottomRight;
             void S_ValueChanged(object sender, RoutedPropertyChangedEventArgs<double> e)
             {
@@ -98,8 +97,8 @@ namespace Cryptool.Plugins.ChaCha
             };
             s.ValueChanged += S_ValueChanged;
             s.VerticalAlignment = VerticalAlignment.Center;
-            TextBlock current = new TextBlock() { VerticalAlignment = VerticalAlignment.Center };
-            current.SetBinding(TextBlock.TextProperty, currentActionIndexBinding);
+            TextBox current = new TextBox { VerticalAlignment = VerticalAlignment.Center, Width = 30 };
+            current.SetBinding(TextBlock.TextProperty, new Binding("CurrentActionIndex") { Mode = BindingMode.TwoWay });
             TextBlock delimiter = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = "/" };
             TextBlock total = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = totalActions.ToString() };
             actionNavBar.Children.Add(PrevButton());

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -445,7 +445,6 @@ namespace Cryptool.Plugins.ChaCha
             string searchLabel = string.Format("_QR_ACTION_LABEL_{0}_{1}", qrLabelSearchIndex, roundLabelSearchIndex);
             int qrActionIndex = GetLabeledPageActionIndex(searchLabel) + 1;
             MoveToAction(qrActionIndex);
-            InitActionNavigationBar(CurrentPage);
         }
         private void QR1_Click(object sender, RoutedEventArgs e)
         {

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -201,7 +201,7 @@ namespace Cryptool.Plugins.ChaCha
         {
             foreach (PageAction pageAction in p.InitActions)
             {
-                WrapExecWithNavigation(pageAction);
+                pageAction.Exec();
             }
 
             if (p.ActionFrames > 0)
@@ -260,6 +260,7 @@ namespace Cryptool.Plugins.ChaCha
         }
 
         // Calls FinishPageAction if page action used navigation interface methods.
+        [Obsolete("This method has been deprecated because it was incompatible with caching.", true)]
         private void WrapExecWithNavigation(PageAction pageAction)
         {
             pageAction.Exec();
@@ -468,7 +469,7 @@ namespace Cryptool.Plugins.ChaCha
         }
         private void NextActionClick(object sender, RoutedEventArgs e)
         {
-            WrapExecWithNavigation(CurrentPage.Actions[CurrentActionIndex]);
+            CurrentPage.Actions[CurrentActionIndex].Exec();
             CurrentActionIndex++;
         }
         private void ExecuteCache(int n)

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -490,7 +490,7 @@ namespace Cryptool.Plugins.ChaCha
             int relative = n - CurrentActionIndex;
             // Console.WriteLine($"MoveToAction({n}) - CurrentActionIndex: {CurrentActionIndex}, relative: {relative}");
             // TODO check if action is cached
-            if (cache.Includes(n))
+            if (relative != 0 && cache.Includes(n))
             {
                 ExecuteCache(n);
             }

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -98,7 +98,7 @@ namespace Cryptool.Plugins.ChaCha
             s.ValueChanged += S_ValueChanged;
             s.VerticalAlignment = VerticalAlignment.Center;
             TextBox current = new TextBox { VerticalAlignment = VerticalAlignment.Center, Width = 30 };
-            current.SetBinding(TextBlock.TextProperty, new Binding("CurrentActionIndex") { Mode = BindingMode.OneWay });
+            current.SetBinding(TextBox.TextProperty, new Binding("CurrentActionIndex") { Mode = BindingMode.TwoWay });
             TextBlock delimiter = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = "/" };
             TextBlock total = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = totalActions.ToString() };
             actionNavBar.Children.Add(PrevButton());

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -332,6 +332,7 @@ namespace Cryptool.Plugins.ChaCha
             set
             {
                 _currentActionIndex = value;
+                // Console.WriteLine($"CurrentActionIndex = {n}");
                 CurrentActionIndexTextBox = value;
                 OnPropertyChanged("CurrentActionIndex");
                 OnPropertyChanged("CurrentActions");
@@ -475,7 +476,6 @@ namespace Cryptool.Plugins.ChaCha
             // Console.WriteLine($"ExecuteCache({n})");
             cache.Get(n).Exec();
             CurrentActionIndex = n;
-            // Console.WriteLine($"CurrentActionIndex = {n}");
             _moveToActionIndicesStack.Clear();
             // Console.WriteLine("Cleared action stack");
         }

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -9,6 +9,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
+using System.Windows.Input;
 using System.Windows.Threading;
 
 namespace Cryptool.Plugins.ChaCha
@@ -99,7 +100,22 @@ namespace Cryptool.Plugins.ChaCha
             s.VerticalAlignment = VerticalAlignment.Center;
             TextBox current = new TextBox { VerticalAlignment = VerticalAlignment.Center, Width = 30 };
             current.SetBinding(TextBox.TextProperty,
-                new Binding("CurrentActionIndex_") { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged});
+                new Binding("CurrentActionIndexTextBox") { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged});
+
+            void HandleKeyDown(object sender, KeyEventArgs e)
+            {
+                if (e.Key == Key.Return)
+                {
+                    string text = ((TextBox)sender).Text;
+                    int value;
+                    if (int.TryParse(text, out value))
+                    {
+                        MoveToActionAsync(value);
+                    }
+                }
+            }
+
+            current.KeyDown += HandleKeyDown;
             TextBlock delimiter = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = "/" };
             TextBlock total = new TextBlock() { VerticalAlignment = VerticalAlignment.Center, Text = totalActions.ToString() };
             actionNavBar.Children.Add(PrevButton());
@@ -234,6 +250,9 @@ namespace Cryptool.Plugins.ChaCha
 
         private int _currentPageIndex = 0;
         private int _currentActionIndex = 0;
+        // action index value for TextBox.
+        // Prevents direct write-access to actual current action index value while still being able to read from it.
+        private int _currentActionIndexTextBox = 0;
 
         private bool _executionFinished = false;
         private bool _inputValid = false;
@@ -262,8 +281,8 @@ namespace Cryptool.Plugins.ChaCha
             set
             {
                 _currentActionIndex = value;
+                CurrentActionIndexTextBox = value;
                 OnPropertyChanged("CurrentActionIndex");
-                OnPropertyChanged("CurrentActionIndex_");
                 OnPropertyChanged("CurrentActions");
                 OnPropertyChanged("NextActionIsEnabled");
                 OnPropertyChanged("PrevActionIsEnabled");
@@ -272,13 +291,14 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
-        public int CurrentActionIndex_
+        public int CurrentActionIndexTextBox
         {
-            get => _currentActionIndex;
+            get => _currentActionIndexTextBox;
             set
             {
-                Console.WriteLine($"Set CurrentActionIndex to ${value} from TextBox");
-                MoveToActionAsync(value);
+                _currentActionIndexTextBox = value;
+                OnPropertyChanged("CurrentActionIndexTextBox");
+
             }
         }
 

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -488,7 +488,7 @@ namespace Cryptool.Plugins.ChaCha
         private void MoveToAction(int n)
         {
             int relative = n - CurrentActionIndex;
-            // Console.WriteLine($"MoveToAction({n}) - CurrentActionIndex: {CurrentActionIndex}, relative: {relative}");
+            // if (relative != 0) Console.WriteLine($"MoveToAction({n}) - CurrentActionIndex: {CurrentActionIndex}, relative: {relative}");
             // TODO check if action is cached
             if (relative != 0 && cache.Includes(n))
             {

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -391,21 +391,15 @@ namespace Cryptool.Plugins.ChaCha
                 endIndex = GetLabeledPageActionIndex(string.Format("_ROUND_ACTION_LABEL_{0}", CurrentRoundIndex - 1)) + 1;
             }
             Debug.Assert(startIndex > endIndex);
-            for (int i = startIndex; i > endIndex; --i)
-            {
-                PrevAction_Click(null, null);
-            }
+            MoveToAction(endIndex);
         }
 
         private void NextRound_Click(object sender, RoutedEventArgs e)
         {
             int startIndex = CurrentActionIndex;
-            int endIndex = GetLabeledPageActionIndex(string.Format("_ROUND_ACTION_LABEL_{0}", CurrentRoundIndex + 1));
+            int endIndex = GetLabeledPageActionIndex(string.Format("_ROUND_ACTION_LABEL_{0}", CurrentRoundIndex + 1)) + 1;
             Debug.Assert(startIndex < endIndex);
-            for (int i = startIndex; i <= endIndex; ++i)
-            {
-                NextAction_Click(null, null);
-            }
+            MoveToAction(endIndex);
         }
 
         private void QR_Click(int qrLabelIndex)

--- a/ChaCha/Visualization/Pages/CachePageAction.cs
+++ b/ChaCha/Visualization/Pages/CachePageAction.cs
@@ -6,6 +6,8 @@ namespace Cryptool.Plugins.ChaCha
     {
         public CachePageAction(Action exec) : base(exec, null) { }
 
+        public CachePageAction(): base(() => { }, null) { }
+
         public override void Undo()
         {
             throw new InvalidOperationException("Undo should never be called on a cached page action");

--- a/ChaCha/Visualization/Pages/CachePageAction.cs
+++ b/ChaCha/Visualization/Pages/CachePageAction.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Cryptool.Plugins.ChaCha
+{
+    class CachePageAction: PageAction
+    {
+        public CachePageAction(Action exec) : base(exec, null) { }
+
+        public override void Undo()
+        {
+            throw new InvalidOperationException("Undo should never be called on a cached page action");
+        }
+    }
+}

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -414,7 +414,7 @@ namespace Cryptool.Plugins.ChaCha
                 );
         }
 
-        private static (int, int, int, int) GetStateIndices(int qrIndex)
+        private static (int, int, int, int) GetStateIndicesFromQRIndex(int qrIndex)
         {
             switch (((qrIndex - 1) % 8) + 1)
             {
@@ -435,7 +435,32 @@ namespace Cryptool.Plugins.ChaCha
                 case 8:
                     return (3, 4, 9, 14);
                 default:
-                    Debug.Assert(false, string.Format("No state indices found for round", qrIndex));
+                    Debug.Assert(false, string.Format("No state indices found for qrIndex", qrIndex));
+                    return (-1, -1, -1, -1);
+            }
+        }
+        public static (int, int, int, int) GetStateIndices(int round)
+        {
+            switch (round)
+            {
+                case 1:
+                    return (0, 4, 8, 12);
+                case 2:
+                    return (1, 5, 9, 13);
+                case 3:
+                    return (2, 6, 10, 14);
+                case 4:
+                    return (3, 7, 11, 15);
+                case 5:
+                    return (0, 5, 10, 15);
+                case 6:
+                    return (1, 6, 11, 12);
+                case 7:
+                    return (2, 7, 8, 13);
+                case 8:
+                    return (3, 4, 9, 14);
+                default:
+                    Debug.Assert(false, string.Format("No state indices found for round", round));
                     return (-1, -1, -1, -1);
             }
         }
@@ -446,7 +471,7 @@ namespace Cryptool.Plugins.ChaCha
         private static PageAction[] CopyFromStateTOQRInputActions(ChaChaPresentation pres, int qrIndex, int round)
         {
             uint[] state = pres.GetResult(ResultType.CHACHA_HASH_ROUND, round - 1);
-            (int i, int j, int k, int l) = GetStateIndices(qrIndex);
+            (int i, int j, int k, int l) = GetStateIndicesFromQRIndex(qrIndex);
             Border[] stateCells = new Border[] { GetStateCell(pres, i), GetStateCell(pres, j), GetStateCell(pres, k), GetStateCell(pres, l) };
             PageAction[] copyActions = pres.Nav.CopyActions(stateCells, 
                 new Border[] { pres.QRInACell, pres.QRInBCell, pres.QRInCCell, pres.QRInDCell },
@@ -504,7 +529,7 @@ namespace Cryptool.Plugins.ChaCha
 
         private static PageAction[] ReplaceStateEntriesWithQROutput(ChaChaPresentation pres, int qrIndex)
         {
-            (int i, int j, int k, int l) = GetStateIndices(qrIndex);
+            (int i, int j, int k, int l) = GetStateIndicesFromQRIndex(qrIndex);
             Border[] stateCells = new Border[] { GetStateCell(pres, i), GetStateCell(pres, j), GetStateCell(pres, k), GetStateCell(pres, l) };
             string[] previousStateEntries = new string[4];
             previousStateEntries[0] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -172,16 +172,25 @@ namespace Cryptool.Plugins.ChaCha
         public static void ClearQRDetail(ChaChaPresentation pres)
         {
             pres.Nav.Clear(pres.QRInA, pres.QRInB, pres.QRInC, pres.QRInD);
+            pres.Nav.UnsetBackground(pres.QRInACell, pres.QRInBCell, pres.QRInCCell, pres.QRInDCell);
             pres.Nav.Clear(pres.QROutA, pres.QROutB, pres.QROutC, pres.QROutD);
+            pres.Nav.UnsetBackground(pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell);
             for (int i = 1; i <= 4; ++i)
             {
                 pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX1", i));
+                pres.Nav.UnsetBackground((Border)GetIndexElement(pres, "QRInX1Cell", i));
                 pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX2", i));
+                pres.Nav.UnsetBackground((Border)GetIndexElement(pres, "QRInX2Cell", i));
                 pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX3", i));
+                pres.Nav.UnsetBackground((Border)GetIndexElement(pres, "QRInX3Cell", i));
                 pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX1", i));
+                pres.Nav.UnsetBackground((Border)GetIndexElement(pres, "QROutX1Cell", i));
                 pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX2", i));
+                pres.Nav.UnsetBackground((Border)GetIndexElement(pres, "QROutX2Cell", i));
                 pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX3", i));
+                pres.Nav.UnsetBackground((Border)GetIndexElement(pres, "QROutX3Cell", i));
                 pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRXOR", i));
+                pres.Nav.UnsetBackground((Border)GetIndexElement(pres, "QRXORCell", i));
             }
         }
         public static PageAction ClearQRDetail(ChaChaPresentation pres, int qrIndex)

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Shapes;
@@ -78,14 +79,19 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
-        public static object GetIndexElement(ChaChaPresentation pres, string nameId, int index)
+        public static object GetIndexElement(ChaChaPresentation pres, string nameId, int index, string delimiter = "_")
         {
-            return pres.FindName(string.Format("{0}_{1}", nameId, index));
+            return pres.FindName(string.Format("{0}{1}{2}", nameId, delimiter, index));
         }
 
         public static Border GetStateCell(ChaChaPresentation pres, int stateIndex)
         {
             return (Border)GetIndexElement(pres, "UIKeystreamBlockGenCell", stateIndex);
+        }
+
+        public static TextBox[] GetStateTextBoxes(ChaChaPresentation pres)
+        {
+            return (TextBox[])Enumerable.Range(0, 15).Select(i => (TextBox)GetIndexElement(pres, "UIKeystreamBlockGen", i, ""));
         }
 
         public static PageAction ClearQRDetail(ChaChaPresentation pres)

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -146,7 +146,17 @@ namespace Cryptool.Plugins.ChaCha
         {
             return Enumerable.Range(0, 16).Select(i => (TextBox)GetIndexElement(pres, "UIKeystreamBlockGen", i, "")).ToArray();
         }
-
+        public static void UnmarkAllStateEntriesExcept(ChaChaPresentation pres, int i, int j, int k, int l)
+        {
+            for(int x = 0; x < 16; ++x)
+            {
+                pres.Nav.UnsetBackground((Border)GetIndexElement(pres, "UIKeystreamBlockGenCell", x));
+            }
+            pres.Nav.SetCopyBackground((Border)GetIndexElement(pres, "UIKeystreamBlockGenCell", i));
+            pres.Nav.SetCopyBackground((Border)GetIndexElement(pres, "UIKeystreamBlockGenCell", j));
+            pres.Nav.SetCopyBackground((Border)GetIndexElement(pres, "UIKeystreamBlockGenCell", k));
+            pres.Nav.SetCopyBackground((Border)GetIndexElement(pres, "UIKeystreamBlockGenCell", l));
+        }
         public static void HideAllQRArrowsExcept(ChaChaPresentation pres, int arrowIndex)
         {
             ((TextBox)GetIndexElement(pres, "ArrowQRRound", 1)).Visibility = Visibility.Hidden;

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -91,7 +91,13 @@ namespace Cryptool.Plugins.ChaCha
 
         public static TextBox[] GetStateTextBoxes(ChaChaPresentation pres)
         {
-            return (TextBox[])Enumerable.Range(0, 15).Select(i => (TextBox)GetIndexElement(pres, "UIKeystreamBlockGen", i, ""));
+            return Enumerable.Range(0, 16).Select(i => (TextBox)GetIndexElement(pres, "UIKeystreamBlockGen", i, "")).ToArray();
+        }
+
+        public static void HideAllQRArrowsExcept(ChaChaPresentation pres, int arrowIndex)
+        {
+            Enumerable.Range(1, 8).Select(i => ((TextBox)GetIndexElement(pres, "ArrowQRRound", i)).Visibility = Visibility.Hidden);
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", arrowIndex)).Visibility = Visibility.Visible;
         }
 
         public static PageAction ClearQRDetail(ChaChaPresentation pres)

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -380,7 +380,7 @@ namespace Cryptool.Plugins.ChaCha
                 b,
                 new Shape[] { (Shape)GetIndexElement(pres, "QRInX1Path", actionIndex), (Shape)GetIndexElement(pres, "QRInX2Path", actionIndex), (Shape)GetIndexElement(pres, "QRInX3Path", actionIndex) },
                 new Border[] { (Border)GetIndexElement(pres, "QRInX1Cell", actionIndex), (Border)GetIndexElement(pres, "QRInX2Cell", actionIndex), (Border)GetIndexElement(pres, "QRInX3Cell", actionIndex) },
-                new string[] { "", "", "", "" }
+                new string[] { "", "", "" }
                 );
         }
 

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -444,20 +444,32 @@ namespace Cryptool.Plugins.ChaCha
             switch (round)
             {
                 case 1:
+                case 9:
+                case 17:
                     return (0, 4, 8, 12);
                 case 2:
+                case 10:
+                case 18:
                     return (1, 5, 9, 13);
                 case 3:
+                case 11:
+                case 19:
                     return (2, 6, 10, 14);
                 case 4:
+                case 12:
+                case 20:
                     return (3, 7, 11, 15);
                 case 5:
+                case 13:
                     return (0, 5, 10, 15);
                 case 6:
+                case 14:
                     return (1, 6, 11, 12);
                 case 7:
+                case 15:
                     return (2, 7, 8, 13);
                 case 8:
+                case 16:
                     return (3, 4, 9, 14);
                 default:
                     Debug.Assert(false, $"No state indices found for round {round}");

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -477,10 +477,10 @@ namespace Cryptool.Plugins.ChaCha
             (int i, int j, int k, int l) = GetStateIndices(qrIndex);
             Border[] stateCells = new Border[] { GetStateCell(pres, i), GetStateCell(pres, j), GetStateCell(pres, k), GetStateCell(pres, l) };
             string[] previousStateEntries = new string[4];
-            previousStateEntries[0] = pres.GetHexResult(ResultType.QR_OUTPUT_A, qrIndex - 1);
-            previousStateEntries[1] = pres.GetHexResult(ResultType.QR_OUTPUT_B, qrIndex - 1);
-            previousStateEntries[2] = pres.GetHexResult(ResultType.QR_OUTPUT_C, qrIndex - 1);
-            previousStateEntries[3] = pres.GetHexResult(ResultType.QR_OUTPUT_D, qrIndex - 1);
+            previousStateEntries[0] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
+            previousStateEntries[1] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
+            previousStateEntries[2] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
+            previousStateEntries[3] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
             return pres.Nav.CopyActions(new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }, stateCells, previousStateEntries, true);
         }
     }

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -482,9 +482,9 @@ namespace Cryptool.Plugins.ChaCha
             Border[] stateCells = new Border[] { GetStateCell(pres, i), GetStateCell(pres, j), GetStateCell(pres, k), GetStateCell(pres, l) };
             string[] previousStateEntries = new string[4];
             previousStateEntries[0] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
-            previousStateEntries[1] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
-            previousStateEntries[2] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
-            previousStateEntries[3] = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
+            previousStateEntries[1] = pres.GetHexResult(ResultType.QR_INPUT_B, qrIndex - 1);
+            previousStateEntries[2] = pres.GetHexResult(ResultType.QR_INPUT_C, qrIndex - 1);
+            previousStateEntries[3] = pres.GetHexResult(ResultType.QR_INPUT_D, qrIndex - 1);
             return pres.Nav.CopyActions(new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }, stateCells, previousStateEntries, true);
         }
     }

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -7,353 +7,359 @@ using System.Windows.Shapes;
 
 namespace Cryptool.Plugins.ChaCha
 {
+    class KeystreamBlockGenPage : Page
+    {
+        ChaChaPresentation _pres;
+        public KeystreamBlockGenPage(ContentControl pageElement, ChaChaPresentation pres) : base(pageElement)
+        {
+            _pres = pres;
+            Init();
+        }
+
+        private void Init()
+        {
+            bool versionIsDJB = _pres.Version == ChaCha.Version.DJB;
+            PageAction initAction = new PageAction(() =>
+            {
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen0, _pres.ConstantsLittleEndian[0]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen1, _pres.ConstantsLittleEndian[1]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen2, _pres.ConstantsLittleEndian[2]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen3, _pres.ConstantsLittleEndian[3]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen4, _pres.KeyLittleEndian[0]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen5, _pres.KeyLittleEndian[1]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen6, _pres.KeyLittleEndian[2]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen7, _pres.KeyLittleEndian[3]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen8, _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 4 : 0]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen9, _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 5 : 1]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen10, _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 6 : 2]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen11, _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 7 : 3]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen12, _pres.InitialCounterLittleEndian[0]);
+                if (versionIsDJB)
+                {
+                    _pres.Nav.Replace(_pres.UIKeystreamBlockGen13, _pres.InitialCounterLittleEndian[1]);
+                }
+                else
+                {
+                    _pres.Nav.Replace(_pres.UIKeystreamBlockGen13, _pres.IVLittleEndian[0]);
+                }
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen14, _pres.IVLittleEndian[versionIsDJB ? 0 : 1]);
+                _pres.Nav.Replace(_pres.UIKeystreamBlockGen15, _pres.IVLittleEndian[versionIsDJB ? 1 : 2]);
+            }, _pres.Nav.Undo);
+            AddInitAction(initAction);
+            PageAction generalDescriptionAction = new PageAction(() =>
+            {
+                string desc = "To generate a keystream block, we apply the ChaCha Hash function to the state. "
+                    + "The ChaCha hash function consists of X rounds. One round applies the quarterround function four times hence the name \"quarterround\". The quarterround function takes in 4 state entries and modifies them.";
+                _pres.Nav.AddBold(_pres.UIKeystreamBlockGenStepDescription, desc);
+            }, _pres.Nav.Undo);
+            PageAction firstColumnRoundDescriptionAction = new PageAction(() =>
+            {
+                string desc = "The first round consists of 4 so called column rounds since we will first select all entries in a column as the input to the quarterround function. ";
+                _pres.Nav.UnboldLast(_pres.UIKeystreamBlockGenStepDescription);
+                _pres.Nav.AddBold(_pres.UIKeystreamBlockGenStepDescription, desc);
+            }, _pres.Nav.Undo);
+            AddAction(generalDescriptionAction);
+            AddAction(firstColumnRoundDescriptionAction);
+
+            for (int qrIndex = 1; qrIndex <= _pres.Rounds * 4; ++qrIndex)
+            {
+                AddAction(CopyFromStateTOQRInputActions(_pres, qrIndex));
+                AddAction(CopyToQRDetailInput(_pres, new Border[] { _pres.QRInACell, _pres.QRInBCell, _pres.QRInDCell }, 1));
+                AddAction(QRExecActions(_pres, 1, qrIndex));
+                AddAction(CopyToQRDetailInput(_pres, new Border[] { _pres.QRInCCell, (Border)GetIndexElement(_pres, "QROutX3Cell", 1), (Border)GetIndexElement(_pres, "QROutX2Cell", 1) }, 2));
+                AddAction(QRExecActions(_pres, 2, qrIndex));
+                AddAction(CopyToQRDetailInput(_pres, new Border[] { (Border)GetIndexElement(_pres, "QROutX1Cell", 1), (Border)GetIndexElement(_pres, "QROutX3Cell", 2), (Border)GetIndexElement(_pres, "QROutX2Cell", 2) }, 3));
+                AddAction(QRExecActions(_pres, 3, qrIndex));
+                AddAction(CopyToQRDetailInput(_pres, new Border[] { (Border)GetIndexElement(_pres, "QROutX1Cell", 2), (Border)GetIndexElement(_pres, "QROutX3Cell", 3), (Border)GetIndexElement(_pres, "QROutX2Cell", 3) }, 4));
+                AddAction(QRExecActions(_pres, 4, qrIndex));
+                AddAction(QROutputActions(_pres));
+                AddAction(ReplaceStateEntriesWithQROutput(_pres, qrIndex));
+                AddAction(ClearQRDetail(_pres));
+            }
+        }
+
+        public static object GetIndexElement(ChaChaPresentation pres, string nameId, int index)
+        {
+            return pres.FindName(string.Format("{0}_{1}", nameId, index));
+        }
+
+        public static Border GetStateCell(ChaChaPresentation pres, int stateIndex)
+        {
+            return (Border)GetIndexElement(pres, "UIKeystreamBlockGenCell", stateIndex);
+        }
+
+        public static PageAction ClearQRDetail(ChaChaPresentation pres)
+        {
+            return new PageAction(() =>
+            {
+                pres.Nav.Clear(pres.QRInA);
+                pres.Nav.Clear(pres.QRInB, pres.QRInC, pres.QRInD);
+                pres.Nav.Clear(pres.QROutA, pres.QROutB, pres.QROutC, pres.QROutD);
+                for (int i = 1; i <= 4; ++i)
+                {
+                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX1", i));
+                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX2", i));
+                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX3", i));
+                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX1", i));
+                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX2", i));
+                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX3", i));
+                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRXOR", i));
+                }
+            }, pres.Nav.Undo);
+        }
+
+        private static int ResultIndex(int actionIndex, int qrIndex)
+        {
+            return (qrIndex - 1) * 4 + (actionIndex - 1);
+        }
+
+        private static PageAction[] QROutputActions(ChaChaPresentation pres)
+        {
+            return pres.Nav.CopyActions(
+                new Border[] { (Border)GetIndexElement(pres, "QROutX1Cell", 3), (Border)GetIndexElement(pres, "QROutX3Cell", 4), (Border)GetIndexElement(pres, "QROutX1Cell", 4), (Border)GetIndexElement(pres, "QROutX2Cell", 4) },
+                new Shape[] { pres.QROutAPath, pres.QROutBPath, pres.QROutCPath, pres.QROutDPath },
+                new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }
+                );
+        }
+
+        private static PageAction[] X1OutActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
+        {
+            PageAction markOutX1 = new PageAction(() =>
+            {
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRInX1Cell", actionIndex));
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRInX2Cell", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "AddInputPathX1", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "AddInputPathX2", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX1", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX2_1", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "AddCircle", actionIndex));
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QROutX1Cell", actionIndex));
+            }, pres.Nav.Undo);
+            PageAction execOutX1 = new PageAction(() =>
+            {
+                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX1", actionIndex), pres.GetHexResult(ResultType.QR_ADD_X1_X2, ResultIndex(actionIndex, qrIndex)));
+            }, pres.Nav.Undo);
+            PageAction unmarkOutX1 = new PageAction(() =>
+            {
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRInX1Cell", actionIndex));
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRInX2Cell", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "AddInputPathX1", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "AddInputPathX2", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX1", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX2_1", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "AddCircle", actionIndex));
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QROutX1Cell", actionIndex));
+            }, pres.Nav.Undo);
+            return new PageAction[] { markOutX1, execOutX1, unmarkOutX1 };
+        }
+
+        private static PageAction[] X2OutActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
+        {
+            PageAction markOutX2 = new PageAction(() =>
+            {
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRInX2Cell", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX2_1", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX2_2", actionIndex));
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QROutX2Cell", actionIndex));
+            }, pres.Nav.Undo);
+            PageAction execOutX2 = new PageAction(() =>
+            {
+                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX2", actionIndex), pres.GetHexResult(ResultType.QR_OUTPUT_X2, ResultIndex(actionIndex, qrIndex)));
+            }, pres.Nav.Undo);
+            PageAction unmarkOutX2 = new PageAction(() =>
+            {
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRInX2Cell", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX2_1", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX2_2", actionIndex));
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QROutX2Cell", actionIndex));
+            }, pres.Nav.Undo);
+            return new PageAction[] { markOutX2, execOutX2, unmarkOutX2 };
+        }
+
+        private static PageAction[] XORActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
+        {
+            PageAction markXOR = new PageAction(() =>
+            {
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRInX3Cell", actionIndex));
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QROutX1Cell", actionIndex));
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRXORCell", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX3_1", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "XORInputPathX1", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "XORCircle", actionIndex));
+            }, pres.Nav.Undo);
+            PageAction execXOR = new PageAction(() =>
+            {
+                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRXOR", actionIndex), pres.GetHexResult(ResultType.QR_XOR, ResultIndex(actionIndex, qrIndex)));
+            }, pres.Nav.Undo);
+            PageAction unmarkXOR = new PageAction(() =>
+            {
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRInX3Cell", actionIndex));
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QROutX1Cell", actionIndex));
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRXORCell", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX3_1", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "XORInputPathX1", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "XORCircle", actionIndex));
+            }, pres.Nav.Undo);
+            return new PageAction[] { markXOR, execXOR, unmarkXOR };
+        }
+
+        private static PageAction[] ShiftActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
+        {
+            PageAction markShift = new PageAction(() =>
+            {
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QROutX3Cell", actionIndex));
+                pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRXORCell", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX3_2", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX3_3", actionIndex));
+                pres.Nav.MarkShape((Shape)GetIndexElement(pres, "ShiftCircle", actionIndex));
+            }, pres.Nav.Undo);
+            PageAction execShift = new PageAction(() =>
+            {
+                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX3", actionIndex), pres.GetHexResult(ResultType.QR_OUTPUT_X3, ResultIndex(actionIndex, qrIndex)));
+            }, pres.Nav.Undo);
+            PageAction unmarkShift = new PageAction(() =>
+            {
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QROutX3Cell", actionIndex));
+                pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRXORCell", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX3_2", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX3_3", actionIndex));
+                pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "ShiftCircle", actionIndex));
+            }, pres.Nav.Undo);
+            return new PageAction[] { markShift, execShift, unmarkShift };
+        }
+
+        private static PageAction[] X3OutActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
+        {
+            PageAction[] xorActions = XORActions(pres, actionIndex, qrIndex);
+            PageAction[] shiftActions = ShiftActions(pres, actionIndex, qrIndex);
+            PageAction[] actions = new PageAction[xorActions.Length + shiftActions.Length];
+            xorActions.CopyTo(actions, 0);
+            shiftActions.CopyTo(actions, xorActions.Length);
+            return actions;
+        }
+
+        private static PageAction[] QRExecActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
+        {
+            List<PageAction> actions = new List<PageAction>();
+            PageAction[] x1OutActions = X1OutActions(pres, actionIndex, qrIndex);
+            PageAction[] x2OutActions = X2OutActions(pres, actionIndex, qrIndex);
+            PageAction[] x3OutActions = X3OutActions(pres, actionIndex, qrIndex);
+            actions.AddRange(x1OutActions);
+            actions.AddRange(x2OutActions);
+            actions.AddRange(x3OutActions);
+            return actions.ToArray();
+        }
+
+        private static PageAction[] CopyToQRDetailInput(ChaChaPresentation pres, Border[] b, int actionIndex)
+        {
+            return pres.Nav.CopyActions(
+                b,
+                new Shape[] { (Shape)GetIndexElement(pres, "QRInX1Path", actionIndex), (Shape)GetIndexElement(pres, "QRInX2Path", actionIndex), (Shape)GetIndexElement(pres, "QRInX3Path", actionIndex) },
+                new Border[] { (Border)GetIndexElement(pres, "QRInX1Cell", actionIndex), (Border)GetIndexElement(pres, "QRInX2Cell", actionIndex), (Border)GetIndexElement(pres, "QRInX3Cell", actionIndex) }
+                );
+        }
+
+        private static int[] GetStateIndices(int qrIndex)
+        {
+            switch (((qrIndex - 1) % 8) + 1)
+            {
+                case 1:
+                    return new int[] { 0, 4, 8, 12 };
+                case 2:
+                    return new int[] { 1, 5, 9, 13 };
+                case 3:
+                    return new int[] { 2, 6, 10, 14 };
+                case 4:
+                    return new int[] { 3, 7, 11, 15 };
+                case 5:
+                    return new int[] { 0, 5, 10, 15 };
+                case 6:
+                    return new int[] { 1, 6, 11, 12 };
+                case 7:
+                    return new int[] { 2, 7, 8, 13 };
+                case 8:
+                    return new int[] { 3, 4, 9, 14 };
+                default:
+                    Debug.Assert(false, string.Format("No state indices found for round", qrIndex));
+                    return new int[0];
+            }
+        }
+        private static PageAction[] CopyFromStateTOQRInputActions(ChaChaPresentation pres, int qrIndex)
+        {
+            int[] stateIndices = GetStateIndices(qrIndex);
+            int i = stateIndices[0];
+            int j = stateIndices[1];
+            int k = stateIndices[2];
+            int l = stateIndices[3];
+            Border[] stateCells = new Border[] { GetStateCell(pres, i), GetStateCell(pres, j), GetStateCell(pres, k), GetStateCell(pres, l) };
+            PageAction[] copyActions = pres.Nav.CopyActions(stateCells, new Border[] { pres.QRInACell, pres.QRInBCell, pres.QRInCCell, pres.QRInDCell });
+            int round = (int)Math.Floor((double)(qrIndex - 1) / 4) + 1;
+            if ((qrIndex - 1) % 4 == 0)
+            {
+                // new round begins
+                PageAction updateRoundCount = new PageAction(() =>
+                {
+                    pres.CurrentRoundIndex = round;
+                    pres.Nav.Replace(pres.CurrentRound, round.ToString());
+                }, () =>
+                {
+                    string text = "";
+                    if (round > 1)
+                    {
+                        text = (round - 1).ToString();
+                    }
+                    else if (round == 1)
+                    {
+                        text = "-";
+                    }
+                    pres.CurrentRoundIndex = round - 1;
+                    pres.Nav.Replace(pres.CurrentRound, text);
+                });
+                copyActions[0].Add(updateRoundCount);
+                copyActions[0].AddLabel(string.Format("_ROUND_ACTION_LABEL_{0}", round));
+            }
+            int QR_ARROW_MAX_INDEX = 8;
+            (int, int) calculateQRArrowIndex(int qrIndex_)
+            {
+                int qrArrowIndex = ((qrIndex_ - 1) % QR_ARROW_MAX_INDEX) + 1;
+                int qrPrevArrowIndex = qrArrowIndex == 1 ? QR_ARROW_MAX_INDEX : qrArrowIndex - 1;
+                return (qrArrowIndex, qrPrevArrowIndex);
+            }
+            PageAction updateQRArrow = new PageAction(() =>
+            {
+                (int qrArrowIndex, int qrPrevArrowIndex) = calculateQRArrowIndex(qrIndex);
+                ((TextBox)GetIndexElement(pres, "ArrowQRRound", qrPrevArrowIndex)).Visibility = Visibility.Hidden;
+                ((TextBox)GetIndexElement(pres, "ArrowQRRound", qrArrowIndex)).Visibility = Visibility.Visible;
+            }, () =>
+            {
+                if (qrIndex > 1)
+                {
+                    (int qrArrowIndex, int qrPrevArrowIndex) = calculateQRArrowIndex(qrIndex);
+                    ((TextBox)GetIndexElement(pres, "ArrowQRRound", qrPrevArrowIndex)).Visibility = Visibility.Visible;
+                    ((TextBox)GetIndexElement(pres, "ArrowQRRound", qrArrowIndex)).Visibility = Visibility.Hidden;
+                }
+            });
+            copyActions[0].Add(updateQRArrow);
+            copyActions[0].AddLabel(string.Format("_QR_ACTION_LABEL_{0}_{1}", ((qrIndex - 1) % 4) + 1, round));
+            return copyActions;
+        }
+
+        private static PageAction[] ReplaceStateEntriesWithQROutput(ChaChaPresentation pres, int qrIndex)
+        {
+            int[] stateIndices = GetStateIndices(qrIndex);
+            int i = stateIndices[0];
+            int j = stateIndices[1];
+            int k = stateIndices[2];
+            int l = stateIndices[3];
+            Border[] stateCells = new Border[] { GetStateCell(pres, i), GetStateCell(pres, j), GetStateCell(pres, k), GetStateCell(pres, l) };
+            return pres.Nav.CopyActions(new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }, stateCells, true);
+        }
+    }
     partial class Page
     {
         public static Page KeystreamBlockGenPage(ChaChaPresentation pres)
         {
-            int ResultIndex(int actionIndex, int qrIndex)
-            {
-                return (qrIndex - 1) * 4 + (actionIndex - 1);
-            }
-            object GetIndexElement(string nameId, int index)
-            {
-                return pres.FindName(string.Format("{0}_{1}", nameId, index));
-            }
-
-            PageAction[] QROutputActions()
-            {
-                return pres.Nav.CopyActions(
-                    new Border[] { (Border)GetIndexElement("QROutX1Cell", 3), (Border)GetIndexElement("QROutX3Cell", 4), (Border)GetIndexElement("QROutX1Cell", 4), (Border)GetIndexElement("QROutX2Cell", 4) },
-                    new Shape[] { pres.QROutAPath, pres.QROutBPath, pres.QROutCPath, pres.QROutDPath },
-                    new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }
-                    );
-            }
-
-            PageAction[] X1OutActions(int actionIndex, int qrIndex)
-            {
-                PageAction markOutX1 = new PageAction(() =>
-                {
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QRInX1Cell", actionIndex));
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QRInX2Cell", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("AddInputPathX1", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("AddInputPathX2", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("OutputPathX1", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("OutputPathX2_1", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("AddCircle", actionIndex));
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QROutX1Cell", actionIndex));
-                }, pres.Nav.Undo);
-                PageAction execOutX1 = new PageAction(() =>
-                {
-                    pres.Nav.Replace((TextBox)GetIndexElement("QROutX1", actionIndex), pres.GetHexResult(ResultType.QR_ADD_X1_X2, ResultIndex(actionIndex, qrIndex)));
-                }, pres.Nav.Undo);
-                PageAction unmarkOutX1 = new PageAction(() =>
-                {
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QRInX1Cell", actionIndex));
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QRInX2Cell", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("AddInputPathX1", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("AddInputPathX2", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("OutputPathX1", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("OutputPathX2_1", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("AddCircle", actionIndex));
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QROutX1Cell", actionIndex));
-                }, pres.Nav.Undo);
-                return new PageAction[] { markOutX1, execOutX1, unmarkOutX1 };
-            }
-
-            PageAction[] X2OutActions(int actionIndex, int qrIndex)
-            {
-                PageAction markOutX2 = new PageAction(() =>
-                {
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QRInX2Cell", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("OutputPathX2_1", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("OutputPathX2_2", actionIndex));
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QROutX2Cell", actionIndex));
-                }, pres.Nav.Undo);
-                PageAction execOutX2 = new PageAction(() =>
-                {
-                    pres.Nav.Replace((TextBox)GetIndexElement("QROutX2", actionIndex), pres.GetHexResult(ResultType.QR_OUTPUT_X2, ResultIndex(actionIndex, qrIndex)));
-                }, pres.Nav.Undo);
-                PageAction unmarkOutX2 = new PageAction(() =>
-                {
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QRInX2Cell", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("OutputPathX2_1", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("OutputPathX2_2", actionIndex));
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QROutX2Cell", actionIndex));
-                }, pres.Nav.Undo);
-                return new PageAction[] { markOutX2, execOutX2, unmarkOutX2 };
-            }
-
-            PageAction[] XORActions(int actionIndex, int qrIndex)
-            {
-                PageAction markXOR = new PageAction(() =>
-                {
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QRInX3Cell", actionIndex));
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QROutX1Cell", actionIndex));
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QRXORCell", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("OutputPathX3_1", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("XORInputPathX1", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("XORCircle", actionIndex));
-                }, pres.Nav.Undo);
-                PageAction execXOR = new PageAction(() =>
-                {
-                    pres.Nav.Replace((TextBox)GetIndexElement("QRXOR", actionIndex), pres.GetHexResult(ResultType.QR_XOR, ResultIndex(actionIndex, qrIndex)));
-                }, pres.Nav.Undo);
-                PageAction unmarkXOR = new PageAction(() =>
-                {
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QRInX3Cell", actionIndex));
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QROutX1Cell", actionIndex));
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QRXORCell", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("OutputPathX3_1", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("XORInputPathX1", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("XORCircle", actionIndex));
-                }, pres.Nav.Undo);
-                return new PageAction[] { markXOR, execXOR, unmarkXOR };
-            }
-
-            PageAction[] ShiftActions(int actionIndex, int qrIndex)
-            {
-                PageAction markShift = new PageAction(() =>
-                {
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QROutX3Cell", actionIndex));
-                    pres.Nav.MarkBorder((Border)GetIndexElement("QRXORCell", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("OutputPathX3_2", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("OutputPathX3_3", actionIndex));
-                    pres.Nav.MarkShape((Shape)GetIndexElement("ShiftCircle", actionIndex));
-                }, pres.Nav.Undo);
-                PageAction execShift = new PageAction(() =>
-                {
-                    pres.Nav.Replace((TextBox)GetIndexElement("QROutX3", actionIndex), pres.GetHexResult(ResultType.QR_OUTPUT_X3, ResultIndex(actionIndex, qrIndex)));
-                }, pres.Nav.Undo);
-                PageAction unmarkShift = new PageAction(() =>
-                {
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QROutX3Cell", actionIndex));
-                    pres.Nav.UnmarkBorder((Border)GetIndexElement("QRXORCell", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("OutputPathX3_2", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("OutputPathX3_3", actionIndex));
-                    pres.Nav.UnmarkShape((Shape)GetIndexElement("ShiftCircle", actionIndex));
-                }, pres.Nav.Undo);
-                return new PageAction[] { markShift, execShift, unmarkShift };
-            }
-
-            PageAction[] X3OutActions(int actionIndex, int qrIndex)
-            {
-                PageAction[] xorActions = XORActions(actionIndex, qrIndex);
-                PageAction[] shiftActions = ShiftActions(actionIndex, qrIndex);
-                PageAction[] actions = new PageAction[xorActions.Length + shiftActions.Length];
-                xorActions.CopyTo(actions, 0);
-                shiftActions.CopyTo(actions, xorActions.Length);
-                return actions;
-            }
-
-            PageAction[] QRExecActions(int actionIndex, int qrIndex)
-            {
-                List<PageAction> actions = new List<PageAction>();
-                PageAction[] x1OutActions = X1OutActions(actionIndex, qrIndex);
-                PageAction[] x2OutActions = X2OutActions(actionIndex, qrIndex);
-                PageAction[] x3OutActions = X3OutActions(actionIndex, qrIndex);
-                actions.AddRange(x1OutActions);
-                actions.AddRange(x2OutActions);
-                actions.AddRange(x3OutActions);
-                return actions.ToArray();
-            }
-
-            PageAction[] CopyToQRDetailInput(Border[] b, int actionIndex)
-            {
-                return pres.Nav.CopyActions(
-                    b,
-                    new Shape[] { (Shape)GetIndexElement("QRInX1Path", actionIndex), (Shape)GetIndexElement("QRInX2Path", actionIndex), (Shape)GetIndexElement("QRInX3Path", actionIndex) },
-                    new Border[] { (Border)GetIndexElement("QRInX1Cell", actionIndex), (Border)GetIndexElement("QRInX2Cell", actionIndex), (Border)GetIndexElement("QRInX3Cell", actionIndex) }
-                    );
-            }
-
-            Border GetStateCell(int stateIndex)
-            {
-                return (Border)GetIndexElement("UIKeystreamBlockGenCell", stateIndex);
-            }
-
-            int[] GetStateIndices(int qrIndex)
-            {
-                switch (((qrIndex - 1) % 8) + 1)
-                {
-                    case 1:
-                        return new int[] { 0, 4, 8, 12 };
-                    case 2:
-                        return new int[] { 1, 5, 9, 13 };
-                    case 3:
-                        return new int[] { 2, 6, 10, 14 };
-                    case 4:
-                        return new int[] { 3, 7, 11, 15 };
-                    case 5:
-                        return new int[] { 0, 5, 10, 15 };
-                    case 6:
-                        return new int[] { 1, 6, 11, 12 };
-                    case 7:
-                        return new int[] { 2, 7, 8, 13 };
-                    case 8:
-                        return new int[] { 3, 4, 9, 14 };
-                    default:
-                        Debug.Assert(false, string.Format("No state indices found for round", qrIndex));
-                        return new int[0];
-                }
-            }
-            PageAction[] CopyFromStateTOQRInputActions(int qrIndex)
-            {
-                int[] stateIndices = GetStateIndices(qrIndex);
-                int i = stateIndices[0];
-                int j = stateIndices[1];
-                int k = stateIndices[2];
-                int l = stateIndices[3];
-                Border[] stateCells = new Border[] { GetStateCell(i), GetStateCell(j), GetStateCell(k), GetStateCell(l) };
-                PageAction[] copyActions = pres.Nav.CopyActions(stateCells, new Border[] { pres.QRInACell, pres.QRInBCell, pres.QRInCCell, pres.QRInDCell });
-                int round = (int)Math.Floor((double)(qrIndex - 1) / 4) + 1;
-                if ((qrIndex - 1) % 4 == 0)
-                {
-                    // new round begins
-                    PageAction updateRoundCount = new PageAction(() =>
-                    {
-                        pres.CurrentRoundIndex = round;
-                        pres.Nav.Replace(pres.CurrentRound, round.ToString());
-                    }, () =>
-                    {
-                        string text = "";
-                        if (round > 1)
-                        {
-                            text = (round - 1).ToString();
-                        }
-                        else if (round == 1)
-                        {
-                            text = "-";
-                        }
-                        pres.CurrentRoundIndex = round - 1;
-                        pres.Nav.Replace(pres.CurrentRound, text);
-                    });
-                    copyActions[0].Add(updateRoundCount);
-                    copyActions[0].AddLabel(string.Format("_ROUND_ACTION_LABEL_{0}", round));
-                }
-                int QR_ARROW_MAX_INDEX = 8;
-                (int, int) calculateQRArrowIndex(int qrIndex_)
-                {
-                    int qrArrowIndex = ((qrIndex_ - 1) % QR_ARROW_MAX_INDEX) + 1;
-                    int qrPrevArrowIndex = qrArrowIndex == 1 ? QR_ARROW_MAX_INDEX : qrArrowIndex - 1;
-                    return (qrArrowIndex, qrPrevArrowIndex);
-                }
-                PageAction updateQRArrow = new PageAction(() =>
-                {
-                    (int qrArrowIndex, int qrPrevArrowIndex) = calculateQRArrowIndex(qrIndex);
-                    ((TextBox)GetIndexElement("ArrowQRRound", qrPrevArrowIndex)).Visibility = Visibility.Hidden;
-                    ((TextBox)GetIndexElement("ArrowQRRound", qrArrowIndex)).Visibility = Visibility.Visible;
-                }, () =>
-                {
-                    if (qrIndex > 1)
-                    {
-                        (int qrArrowIndex, int qrPrevArrowIndex) = calculateQRArrowIndex(qrIndex);
-                        ((TextBox)GetIndexElement("ArrowQRRound", qrPrevArrowIndex)).Visibility = Visibility.Visible;
-                        ((TextBox)GetIndexElement("ArrowQRRound", qrArrowIndex)).Visibility = Visibility.Hidden;
-                    }
-                });
-                copyActions[0].Add(updateQRArrow);
-                copyActions[0].AddLabel(string.Format("_QR_ACTION_LABEL_{0}_{1}", ((qrIndex - 1) % 4) + 1, round));
-                return copyActions;
-            }
-
-            PageAction[] ReplaceStateEntriesWithQROutput(int qrIndex)
-            {
-                int[] stateIndices = GetStateIndices(qrIndex);
-                int i = stateIndices[0];
-                int j = stateIndices[1];
-                int k = stateIndices[2];
-                int l = stateIndices[3];
-                Border[] stateCells = new Border[] { GetStateCell(i), GetStateCell(j), GetStateCell(k), GetStateCell(l) };
-                return pres.Nav.CopyActions(new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }, stateCells, true);
-            }
-
-            PageAction ClearQRDetail()
-            {
-                return new PageAction(() =>
-                {
-                    pres.Nav.Clear(pres.QRInA);
-                    pres.Nav.Clear(pres.QRInB, pres.QRInC, pres.QRInD);
-                    pres.Nav.Clear(pres.QROutA, pres.QROutB, pres.QROutC, pres.QROutD);
-                    for (int i = 1; i <= 4; ++i)
-                    {
-                        pres.Nav.Clear((TextBox)GetIndexElement("QRInX1", i));
-                        pres.Nav.Clear((TextBox)GetIndexElement("QRInX2", i));
-                        pres.Nav.Clear((TextBox)GetIndexElement("QRInX3", i));
-                        pres.Nav.Clear((TextBox)GetIndexElement("QROutX1", i));
-                        pres.Nav.Clear((TextBox)GetIndexElement("QROutX2", i));
-                        pres.Nav.Clear((TextBox)GetIndexElement("QROutX3", i));
-                        pres.Nav.Clear((TextBox)GetIndexElement("QRXOR", i));
-                    }
-                }, pres.Nav.Undo);
-            }
-
-            Page KeystreamBlockGenPage()
-            {
-                Page p = new Page(pres.UIKeystreamBlockGenPage);
-                bool versionIsDJB = pres.Version == ChaCha.Version.DJB;
-                PageAction initAction = new PageAction(() =>
-                {
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen0, pres.ConstantsLittleEndian[0]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen1, pres.ConstantsLittleEndian[1]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen2, pres.ConstantsLittleEndian[2]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen3, pres.ConstantsLittleEndian[3]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen4, pres.KeyLittleEndian[0]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen5, pres.KeyLittleEndian[1]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen6, pres.KeyLittleEndian[2]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen7, pres.KeyLittleEndian[3]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen8, pres.KeyLittleEndian[pres.InputKey.Length == 32 ? 4 : 0]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen9, pres.KeyLittleEndian[pres.InputKey.Length == 32 ? 5 : 1]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen10, pres.KeyLittleEndian[pres.InputKey.Length == 32 ? 6 : 2]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen11, pres.KeyLittleEndian[pres.InputKey.Length == 32 ? 7 : 3]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen12, pres.InitialCounterLittleEndian[0]);
-                    if (versionIsDJB)
-                    {
-                        pres.Nav.Replace(pres.UIKeystreamBlockGen13, pres.InitialCounterLittleEndian[1]);
-                    }
-                    else
-                    {
-                        pres.Nav.Replace(pres.UIKeystreamBlockGen13, pres.IVLittleEndian[0]);
-                    }
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen14, pres.IVLittleEndian[versionIsDJB ? 0 : 1]);
-                    pres.Nav.Replace(pres.UIKeystreamBlockGen15, pres.IVLittleEndian[versionIsDJB ? 1 : 2]);
-                }, pres.Nav.Undo);
-                p.AddInitAction(initAction);
-                PageAction generalDescriptionAction = new PageAction(() =>
-                {
-                    string desc = "To generate a keystream block, we apply the ChaCha Hash function to the state. "
-                        + "The ChaCha hash function consists of X rounds. One round applies the quarterround function four times hence the name \"quarterround\". The quarterround function takes in 4 state entries and modifies them.";
-                    pres.Nav.AddBold(pres.UIKeystreamBlockGenStepDescription, desc);
-                }, pres.Nav.Undo);
-                PageAction firstColumnRoundDescriptionAction = new PageAction(() =>
-                {
-                    string desc = "The first round consists of 4 so called column rounds since we will first select all entries in a column as the input to the quarterround function. ";
-                    pres.Nav.UnboldLast(pres.UIKeystreamBlockGenStepDescription);
-                    pres.Nav.AddBold(pres.UIKeystreamBlockGenStepDescription, desc);
-                }, pres.Nav.Undo);
-                p.AddAction(generalDescriptionAction);
-                p.AddAction(firstColumnRoundDescriptionAction);
-
-                for (int qrIndex = 1; qrIndex <= pres.Rounds * 4; ++qrIndex)
-                {
-                    p.AddAction(CopyFromStateTOQRInputActions(qrIndex));
-                    p.AddAction(CopyToQRDetailInput(new Border[] { pres.QRInACell, pres.QRInBCell, pres.QRInDCell }, 1));
-                    p.AddAction(QRExecActions(1, qrIndex));
-                    p.AddAction(CopyToQRDetailInput(new Border[] { pres.QRInCCell, (Border)GetIndexElement("QROutX3Cell", 1), (Border)GetIndexElement("QROutX2Cell", 1) }, 2));
-                    p.AddAction(QRExecActions(2, qrIndex));
-                    p.AddAction(CopyToQRDetailInput(new Border[] { (Border)GetIndexElement("QROutX1Cell", 1), (Border)GetIndexElement("QROutX3Cell", 2), (Border)GetIndexElement("QROutX2Cell", 2) }, 3));
-                    p.AddAction(QRExecActions(3, qrIndex));
-                    p.AddAction(CopyToQRDetailInput(new Border[] { (Border)GetIndexElement("QROutX1Cell", 2), (Border)GetIndexElement("QROutX3Cell", 3), (Border)GetIndexElement("QROutX2Cell", 3) }, 4));
-                    p.AddAction(QRExecActions(4, qrIndex));
-                    p.AddAction(QROutputActions());
-                    p.AddAction(ReplaceStateEntriesWithQROutput(qrIndex));
-                    p.AddAction(ClearQRDetail());
-                }
-
-                return p;
-            }
-
-            return KeystreamBlockGenPage();
+            return new KeystreamBlockGenPage(pres.UIKeystreamBlockGenPage, pres);
         }
-        
     }
 }

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -200,13 +200,13 @@ namespace Cryptool.Plugins.ChaCha
                 pres.Nav.Replace(pres.QRInD, qrInD);
                 for (int i = 1; i <= 4; ++i)
                 {
-                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX1", i),  qrDetailValues[i, 0]);
-                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX2", i),  qrDetailValues[i, 1]);
-                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX3", i),  qrDetailValues[i, 2]);
-                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX1", i), qrDetailValues[i, 3]);
-                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX2", i), qrDetailValues[i, 4]);
-                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX3", i), qrDetailValues[i, 5]);
-                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRXOR", i),   qrDetailValues[i, 6]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX1", i),  qrDetailValues[i - 1, 0]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX2", i),  qrDetailValues[i - 1, 1]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX3", i),  qrDetailValues[i - 1, 2]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX1", i), qrDetailValues[i - 1, 3]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX2", i), qrDetailValues[i - 1 , 4]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX3", i), qrDetailValues[i - 1, 5]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRXOR", i),   qrDetailValues[i - 1, 6]);
                 }
             });
         }

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
@@ -16,55 +17,107 @@ namespace Cryptool.Plugins.ChaCha
             _pres = pres;
             Init();
         }
-
+        private void AddToState(
+                string state0, string state1, string state2, string state3,
+                string state4, string state5, string state6, string state7,
+                string state8, string state9, string state10, string state11,
+                string state12, string state13, string state14, string state15)
+        {
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen0, state0);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen1, state1);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen2, state2);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen3, state3);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen4, state4);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen5, state5);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen6, state6);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen7, state7);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen8, state8);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen9, state9);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen10, state10);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen11, state11);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen12, state12);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen13, state13);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen14, state14);
+            _pres.Nav.Replace(_pres.UIKeystreamBlockGen15, state15);
+        }
+        private void ClearState()
+        {
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen0);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen1);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen2);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen3);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen4);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen5);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen6);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen7);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen8);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen9);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen10);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen11);
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGen12);
+        }
+        private void AddBoldToDescription(string descToAdd)
+        {
+            _pres.Nav.AddBold(_pres.UIKeystreamBlockGenStepDescription, descToAdd);
+        }
+        private void ClearDescription()
+        {
+            _pres.Nav.Clear(_pres.UIKeystreamBlockGenStepDescription);
+        }
+        private void UnboldLastFromDescription()
+        {
+            _pres.Nav.UnboldLast(_pres.UIKeystreamBlockGenStepDescription);
+        }
+        void MakeLastBoldInDescription()
+        {
+            _pres.Nav.MakeBoldLast(_pres.UIKeystreamBlockGenStepDescription);
+        }
+        void RemoveLastFromDescription()
+        {
+            _pres.Nav.RemoveLast(_pres.UIKeystreamBlockGenStepDescription);
+        }
         private void Init()
         {
             bool versionIsDJB = _pres.Version == ChaCha.Version.DJB;
+            string DESCRIPTION_1 = "To generate a keystream block, we apply the ChaCha Hash function to the state. "
+                    + "The ChaCha hash function consists of X rounds. One round applies the quarterround function four times hence the name \"quarterround\". The quarterround function takes in 4 state entries and modifies them.";
+            string DESCRIPTION_2 = "The first round consists of 4 so called column rounds since we will first select all entries in a column as the input to the quarterround function. ";
             PageAction initAction = new PageAction(() =>
             {
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen0, _pres.ConstantsLittleEndian[0]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen1, _pres.ConstantsLittleEndian[1]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen2, _pres.ConstantsLittleEndian[2]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen3, _pres.ConstantsLittleEndian[3]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen4, _pres.KeyLittleEndian[0]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen5, _pres.KeyLittleEndian[1]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen6, _pres.KeyLittleEndian[2]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen7, _pres.KeyLittleEndian[3]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen8, _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 4 : 0]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen9, _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 5 : 1]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen10, _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 6 : 2]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen11, _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 7 : 3]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen12, _pres.InitialCounterLittleEndian[0]);
-                if (versionIsDJB)
-                {
-                    _pres.Nav.Replace(_pres.UIKeystreamBlockGen13, _pres.InitialCounterLittleEndian[1]);
-                }
-                else
-                {
-                    _pres.Nav.Replace(_pres.UIKeystreamBlockGen13, _pres.IVLittleEndian[0]);
-                }
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen14, _pres.IVLittleEndian[versionIsDJB ? 0 : 1]);
-                _pres.Nav.Replace(_pres.UIKeystreamBlockGen15, _pres.IVLittleEndian[versionIsDJB ? 1 : 2]);
-            }, _pres.Nav.Undo);
+                AddToState(
+                    _pres.ConstantsLittleEndian[0], _pres.ConstantsLittleEndian[1], _pres.ConstantsLittleEndian[2], _pres.ConstantsLittleEndian[3],
+                    _pres.KeyLittleEndian[0], _pres.KeyLittleEndian[1], _pres.KeyLittleEndian[2], _pres.KeyLittleEndian[3],
+                    _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 4 : 0], _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 5 : 1], _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 6 : 2], _pres.KeyLittleEndian[_pres.InputKey.Length == 32 ? 7 : 3],
+                    _pres.InitialCounterLittleEndian[0], versionIsDJB ? _pres.InitialCounterLittleEndian[1] : _pres.IVLittleEndian[0], _pres.IVLittleEndian[versionIsDJB ? 0 : 1], _pres.IVLittleEndian[versionIsDJB ? 1 : 2]
+                    );
+            }, () =>
+            {
+                ClearState();
+            });
             AddInitAction(initAction);
             PageAction generalDescriptionAction = new PageAction(() =>
             {
-                string desc = "To generate a keystream block, we apply the ChaCha Hash function to the state. "
-                    + "The ChaCha hash function consists of X rounds. One round applies the quarterround function four times hence the name \"quarterround\". The quarterround function takes in 4 state entries and modifies them.";
-                _pres.Nav.AddBold(_pres.UIKeystreamBlockGenStepDescription, desc);
-            }, _pres.Nav.Undo);
+                AddBoldToDescription(DESCRIPTION_1);
+            }, () =>
+            {
+                ClearDescription();
+            });
             PageAction firstColumnRoundDescriptionAction = new PageAction(() =>
             {
-                string desc = "The first round consists of 4 so called column rounds since we will first select all entries in a column as the input to the quarterround function. ";
-                _pres.Nav.UnboldLast(_pres.UIKeystreamBlockGenStepDescription);
-                _pres.Nav.AddBold(_pres.UIKeystreamBlockGenStepDescription, desc);
-            }, _pres.Nav.Undo);
+                UnboldLastFromDescription();
+                AddBoldToDescription(DESCRIPTION_2);
+            }, () =>
+            {
+                RemoveLastFromDescription();
+                MakeLastBoldInDescription();
+            });
             AddAction(generalDescriptionAction);
             AddAction(firstColumnRoundDescriptionAction);
 
             for (int qrIndex = 1; qrIndex <= _pres.Rounds * 4; ++qrIndex)
             {
-                AddAction(CopyFromStateTOQRInputActions(_pres, qrIndex));
+                int round = calculateRoundFromQRIndex(qrIndex);
+                AddAction(CopyFromStateTOQRInputActions(_pres, qrIndex, round));
                 AddAction(CopyToQRDetailInput(_pres, new Border[] { _pres.QRInACell, _pres.QRInBCell, _pres.QRInDCell }, 1));
                 AddAction(QRExecActions(_pres, 1, qrIndex));
                 AddAction(CopyToQRDetailInput(_pres, new Border[] { _pres.QRInCCell, (Border)GetIndexElement(_pres, "QROutX3Cell", 1), (Border)GetIndexElement(_pres, "QROutX2Cell", 1) }, 2));
@@ -75,7 +128,7 @@ namespace Cryptool.Plugins.ChaCha
                 AddAction(QRExecActions(_pres, 4, qrIndex));
                 AddAction(QROutputActions(_pres));
                 AddAction(ReplaceStateEntriesWithQROutput(_pres, qrIndex));
-                AddAction(ClearQRDetail(_pres));
+                AddAction(ClearQRDetail(_pres, qrIndex));
             }
         }
 
@@ -99,25 +152,63 @@ namespace Cryptool.Plugins.ChaCha
             Enumerable.Range(1, 8).Select(i => ((TextBox)GetIndexElement(pres, "ArrowQRRound", i)).Visibility = Visibility.Hidden);
             ((TextBox)GetIndexElement(pres, "ArrowQRRound", arrowIndex)).Visibility = Visibility.Visible;
         }
-
-        public static PageAction ClearQRDetail(ChaChaPresentation pres)
+        public static void ClearQRDetail(ChaChaPresentation pres)
         {
+            pres.Nav.Clear(pres.QRInA, pres.QRInB, pres.QRInC, pres.QRInD);
+            pres.Nav.Clear(pres.QROutA, pres.QROutB, pres.QROutC, pres.QROutD);
+            for (int i = 1; i <= 4; ++i)
+            {
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX1", i));
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX2", i));
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX3", i));
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX1", i));
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX2", i));
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX3", i));
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRXOR", i));
+            }
+        }
+        public static PageAction ClearQRDetail(ChaChaPresentation pres, int qrIndex)
+        {
+            string qrInA = pres.GetHexResult(ResultType.QR_INPUT_A, qrIndex - 1);
+            string qrInB = pres.GetHexResult(ResultType.QR_INPUT_B, qrIndex - 1);
+            string qrInC = pres.GetHexResult(ResultType.QR_INPUT_C, qrIndex - 1);
+            string qrInD = pres.GetHexResult(ResultType.QR_INPUT_D, qrIndex - 1);
+            string[,] qrDetailValues = new string[4, 7];
+            for (int i = 0; i < 4; ++i)
+            {
+                qrDetailValues[i, 0] = pres.GetHexResult(ResultType.QR_INPUT_X1, i + qrIndex - 1);
+                qrDetailValues[i, 1] = pres.GetHexResult(ResultType.QR_INPUT_X2, i + qrIndex - 1);
+                qrDetailValues[i, 2] = pres.GetHexResult(ResultType.QR_INPUT_X3, i + qrIndex - 1);
+                qrDetailValues[i, 3] = pres.GetHexResult(ResultType.QR_OUTPUT_X1, i + qrIndex - 1);
+                qrDetailValues[i, 4] = pres.GetHexResult(ResultType.QR_OUTPUT_X2, i + qrIndex - 1);
+                qrDetailValues[i, 5] = pres.GetHexResult(ResultType.QR_OUTPUT_X3, i + qrIndex - 1);
+                qrDetailValues[i, 6] = pres.GetHexResult(ResultType.QR_XOR, i + qrIndex - 1);
+            }
+            string qrOutA = pres.GetHexResult(ResultType.QR_OUTPUT_A, qrIndex - 1);
+            string qrOutB = pres.GetHexResult(ResultType.QR_OUTPUT_B, qrIndex - 1);
+            string qrOutC = pres.GetHexResult(ResultType.QR_OUTPUT_C, qrIndex - 1);
+            string qrOutD = pres.GetHexResult(ResultType.QR_OUTPUT_D, qrIndex - 1);
+
             return new PageAction(() =>
             {
-                pres.Nav.Clear(pres.QRInA);
-                pres.Nav.Clear(pres.QRInB, pres.QRInC, pres.QRInD);
-                pres.Nav.Clear(pres.QROutA, pres.QROutB, pres.QROutC, pres.QROutD);
+                ClearQRDetail(pres);
+            }, () =>
+            {
+                pres.Nav.Replace(pres.QRInA, qrInA);
+                pres.Nav.Replace(pres.QRInB, qrInB);
+                pres.Nav.Replace(pres.QRInC, qrInC);
+                pres.Nav.Replace(pres.QRInD, qrInD);
                 for (int i = 1; i <= 4; ++i)
                 {
-                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX1", i));
-                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX2", i));
-                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRInX3", i));
-                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX1", i));
-                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX2", i));
-                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX3", i));
-                    pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRXOR", i));
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX1", i),  qrDetailValues[i, 0]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX2", i),  qrDetailValues[i, 1]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRInX3", i),  qrDetailValues[i, 2]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX1", i), qrDetailValues[i, 3]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX2", i), qrDetailValues[i, 4]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX3", i), qrDetailValues[i, 5]);
+                    pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRXOR", i),   qrDetailValues[i, 6]);
                 }
-            }, pres.Nav.Undo);
+            });
         }
 
         private static int ResultIndex(int actionIndex, int qrIndex)
@@ -130,13 +221,14 @@ namespace Cryptool.Plugins.ChaCha
             return pres.Nav.CopyActions(
                 new Border[] { (Border)GetIndexElement(pres, "QROutX1Cell", 3), (Border)GetIndexElement(pres, "QROutX3Cell", 4), (Border)GetIndexElement(pres, "QROutX1Cell", 4), (Border)GetIndexElement(pres, "QROutX2Cell", 4) },
                 new Shape[] { pres.QROutAPath, pres.QROutBPath, pres.QROutCPath, pres.QROutDPath },
-                new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }
+                new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell },
+                new string[] { "", "", "", "" }
                 );
         }
 
         private static PageAction[] X1OutActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
         {
-            PageAction markOutX1 = new PageAction(() =>
+            void MarkX1Output()
             {
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRInX1Cell", actionIndex));
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRInX2Cell", actionIndex));
@@ -146,12 +238,8 @@ namespace Cryptool.Plugins.ChaCha
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX2_1", actionIndex));
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "AddCircle", actionIndex));
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QROutX1Cell", actionIndex));
-            }, pres.Nav.Undo);
-            PageAction execOutX1 = new PageAction(() =>
-            {
-                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX1", actionIndex), pres.GetHexResult(ResultType.QR_ADD_X1_X2, ResultIndex(actionIndex, qrIndex)));
-            }, pres.Nav.Undo);
-            PageAction unmarkOutX1 = new PageAction(() =>
+            }
+            void UnmarkX1Output()
             {
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRInX1Cell", actionIndex));
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRInX2Cell", actionIndex));
@@ -161,36 +249,50 @@ namespace Cryptool.Plugins.ChaCha
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX2_1", actionIndex));
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "AddCircle", actionIndex));
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QROutX1Cell", actionIndex));
-            }, pres.Nav.Undo);
+            }
+            PageAction markOutX1 = new PageAction(MarkX1Output, UnmarkX1Output);
+            PageAction execOutX1 = new PageAction(() =>
+            {
+                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX1", actionIndex), pres.GetHexResult(ResultType.QR_ADD_X1_X2, ResultIndex(actionIndex, qrIndex)));
+            }, () =>
+            {
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX1", actionIndex));
+            });
+            PageAction unmarkOutX1 = new PageAction(UnmarkX1Output, MarkX1Output);
             return new PageAction[] { markOutX1, execOutX1, unmarkOutX1 };
         }
 
         private static PageAction[] X2OutActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
         {
-            PageAction markOutX2 = new PageAction(() =>
+            void MarkX2Output()
             {
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRInX2Cell", actionIndex));
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX2_1", actionIndex));
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX2_2", actionIndex));
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QROutX2Cell", actionIndex));
-            }, pres.Nav.Undo);
-            PageAction execOutX2 = new PageAction(() =>
-            {
-                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX2", actionIndex), pres.GetHexResult(ResultType.QR_OUTPUT_X2, ResultIndex(actionIndex, qrIndex)));
-            }, pres.Nav.Undo);
-            PageAction unmarkOutX2 = new PageAction(() =>
+            }
+            void UnmarkX2Output()
             {
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRInX2Cell", actionIndex));
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX2_1", actionIndex));
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX2_2", actionIndex));
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QROutX2Cell", actionIndex));
-            }, pres.Nav.Undo);
+            }
+            PageAction markOutX2 = new PageAction(MarkX2Output, UnmarkX2Output);
+            PageAction execOutX2 = new PageAction(() =>
+            {
+                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX2", actionIndex), pres.GetHexResult(ResultType.QR_OUTPUT_X2, ResultIndex(actionIndex, qrIndex)));
+            }, () =>
+            {
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX2", actionIndex));
+            });
+            PageAction unmarkOutX2 = new PageAction(UnmarkX2Output, MarkX2Output);
             return new PageAction[] { markOutX2, execOutX2, unmarkOutX2 };
         }
 
         private static PageAction[] XORActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
         {
-            PageAction markXOR = new PageAction(() =>
+            void MarkXOR()
             {
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRInX3Cell", actionIndex));
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QROutX1Cell", actionIndex));
@@ -198,12 +300,8 @@ namespace Cryptool.Plugins.ChaCha
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX3_1", actionIndex));
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "XORInputPathX1", actionIndex));
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "XORCircle", actionIndex));
-            }, pres.Nav.Undo);
-            PageAction execXOR = new PageAction(() =>
-            {
-                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRXOR", actionIndex), pres.GetHexResult(ResultType.QR_XOR, ResultIndex(actionIndex, qrIndex)));
-            }, pres.Nav.Undo);
-            PageAction unmarkXOR = new PageAction(() =>
+            }
+            void UnmarkXOR()
             {
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRInX3Cell", actionIndex));
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QROutX1Cell", actionIndex));
@@ -211,32 +309,46 @@ namespace Cryptool.Plugins.ChaCha
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX3_1", actionIndex));
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "XORInputPathX1", actionIndex));
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "XORCircle", actionIndex));
-            }, pres.Nav.Undo);
+            }
+            PageAction markXOR = new PageAction(MarkXOR, UnmarkXOR);
+            PageAction execXOR = new PageAction(() =>
+            {
+                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRXOR", actionIndex), pres.GetHexResult(ResultType.QR_XOR, ResultIndex(actionIndex, qrIndex)));
+            }, () =>
+            {
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QRXOR", actionIndex));
+            });
+            PageAction unmarkXOR = new PageAction(UnmarkXOR, MarkXOR);
             return new PageAction[] { markXOR, execXOR, unmarkXOR };
         }
 
         private static PageAction[] ShiftActions(ChaChaPresentation pres, int actionIndex, int qrIndex)
         {
-            PageAction markShift = new PageAction(() =>
+            void MarkShift()
             {
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QROutX3Cell", actionIndex));
                 pres.Nav.MarkBorder((Border)GetIndexElement(pres, "QRXORCell", actionIndex));
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX3_2", actionIndex));
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "OutputPathX3_3", actionIndex));
                 pres.Nav.MarkShape((Shape)GetIndexElement(pres, "ShiftCircle", actionIndex));
-            }, pres.Nav.Undo);
-            PageAction execShift = new PageAction(() =>
-            {
-                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX3", actionIndex), pres.GetHexResult(ResultType.QR_OUTPUT_X3, ResultIndex(actionIndex, qrIndex)));
-            }, pres.Nav.Undo);
-            PageAction unmarkShift = new PageAction(() =>
+            }
+            void UnmarkShift()
             {
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QROutX3Cell", actionIndex));
                 pres.Nav.UnmarkBorder((Border)GetIndexElement(pres, "QRXORCell", actionIndex));
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX3_2", actionIndex));
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "OutputPathX3_3", actionIndex));
                 pres.Nav.UnmarkShape((Shape)GetIndexElement(pres, "ShiftCircle", actionIndex));
-            }, pres.Nav.Undo);
+            }
+            PageAction markShift = new PageAction(MarkShift, UnmarkShift);
+            PageAction execShift = new PageAction(() =>
+            {
+                pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX3", actionIndex), pres.GetHexResult(ResultType.QR_OUTPUT_X3, ResultIndex(actionIndex, qrIndex)));
+            }, () =>
+            {
+                pres.Nav.Clear((TextBox)GetIndexElement(pres, "QROutX3", actionIndex));
+            });
+            PageAction unmarkShift = new PageAction(UnmarkShift, MarkShift);
             return new PageAction[] { markShift, execShift, unmarkShift };
         }
 
@@ -267,45 +379,49 @@ namespace Cryptool.Plugins.ChaCha
             return pres.Nav.CopyActions(
                 b,
                 new Shape[] { (Shape)GetIndexElement(pres, "QRInX1Path", actionIndex), (Shape)GetIndexElement(pres, "QRInX2Path", actionIndex), (Shape)GetIndexElement(pres, "QRInX3Path", actionIndex) },
-                new Border[] { (Border)GetIndexElement(pres, "QRInX1Cell", actionIndex), (Border)GetIndexElement(pres, "QRInX2Cell", actionIndex), (Border)GetIndexElement(pres, "QRInX3Cell", actionIndex) }
+                new Border[] { (Border)GetIndexElement(pres, "QRInX1Cell", actionIndex), (Border)GetIndexElement(pres, "QRInX2Cell", actionIndex), (Border)GetIndexElement(pres, "QRInX3Cell", actionIndex) },
+                new string[] { "", "", "", "" }
                 );
         }
 
-        private static int[] GetStateIndices(int qrIndex)
+        private static (int, int, int, int) GetStateIndices(int qrIndex)
         {
             switch (((qrIndex - 1) % 8) + 1)
             {
                 case 1:
-                    return new int[] { 0, 4, 8, 12 };
+                    return (0, 4, 8, 12);
                 case 2:
-                    return new int[] { 1, 5, 9, 13 };
+                    return (1, 5, 9, 13);
                 case 3:
-                    return new int[] { 2, 6, 10, 14 };
+                    return (2, 6, 10, 14);
                 case 4:
-                    return new int[] { 3, 7, 11, 15 };
+                    return (3, 7, 11, 15);
                 case 5:
-                    return new int[] { 0, 5, 10, 15 };
+                    return (0, 5, 10, 15);
                 case 6:
-                    return new int[] { 1, 6, 11, 12 };
+                    return (1, 6, 11, 12);
                 case 7:
-                    return new int[] { 2, 7, 8, 13 };
+                    return (2, 7, 8, 13);
                 case 8:
-                    return new int[] { 3, 4, 9, 14 };
+                    return (3, 4, 9, 14);
                 default:
                     Debug.Assert(false, string.Format("No state indices found for round", qrIndex));
-                    return new int[0];
+                    return (-1, -1, -1, -1);
             }
         }
-        private static PageAction[] CopyFromStateTOQRInputActions(ChaChaPresentation pres, int qrIndex)
+        private int calculateRoundFromQRIndex(int qrIndex)
         {
-            int[] stateIndices = GetStateIndices(qrIndex);
-            int i = stateIndices[0];
-            int j = stateIndices[1];
-            int k = stateIndices[2];
-            int l = stateIndices[3];
+            return (int)Math.Floor((double)(qrIndex - 1) / 4) + 1;
+        }
+        private static PageAction[] CopyFromStateTOQRInputActions(ChaChaPresentation pres, int qrIndex, int round)
+        {
+            uint[] state = pres.GetResult(ResultType.CHACHA_HASH_ROUND, round - 1);
+            (int i, int j, int k, int l) = GetStateIndices(qrIndex);
             Border[] stateCells = new Border[] { GetStateCell(pres, i), GetStateCell(pres, j), GetStateCell(pres, k), GetStateCell(pres, l) };
-            PageAction[] copyActions = pres.Nav.CopyActions(stateCells, new Border[] { pres.QRInACell, pres.QRInBCell, pres.QRInCCell, pres.QRInDCell });
-            int round = (int)Math.Floor((double)(qrIndex - 1) / 4) + 1;
+            PageAction[] copyActions = pres.Nav.CopyActions(stateCells, 
+                new Border[] { pres.QRInACell, pres.QRInBCell, pres.QRInCCell, pres.QRInDCell },
+                new string[] { "", "", "", "" }
+                );
             if ((qrIndex - 1) % 4 == 0)
             {
                 // new round begins
@@ -358,13 +474,14 @@ namespace Cryptool.Plugins.ChaCha
 
         private static PageAction[] ReplaceStateEntriesWithQROutput(ChaChaPresentation pres, int qrIndex)
         {
-            int[] stateIndices = GetStateIndices(qrIndex);
-            int i = stateIndices[0];
-            int j = stateIndices[1];
-            int k = stateIndices[2];
-            int l = stateIndices[3];
+            (int i, int j, int k, int l) = GetStateIndices(qrIndex);
             Border[] stateCells = new Border[] { GetStateCell(pres, i), GetStateCell(pres, j), GetStateCell(pres, k), GetStateCell(pres, l) };
-            return pres.Nav.CopyActions(new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }, stateCells, true);
+            string[] previousStateEntries = new string[4];
+            previousStateEntries[0] = pres.GetHexResult(ResultType.QR_OUTPUT_A, qrIndex - 1);
+            previousStateEntries[1] = pres.GetHexResult(ResultType.QR_OUTPUT_B, qrIndex - 1);
+            previousStateEntries[2] = pres.GetHexResult(ResultType.QR_OUTPUT_C, qrIndex - 1);
+            previousStateEntries[3] = pres.GetHexResult(ResultType.QR_OUTPUT_D, qrIndex - 1);
+            return pres.Nav.CopyActions(new Border[] { pres.QROutACell, pres.QROutBCell, pres.QROutCCell, pres.QROutDCell }, stateCells, previousStateEntries, true);
         }
     }
     partial class Page

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -439,43 +439,6 @@ namespace Cryptool.Plugins.ChaCha
                     return (-1, -1, -1, -1);
             }
         }
-        public static (int, int, int, int) GetStateIndices(int round)
-        {
-            switch (round)
-            {
-                case 1:
-                case 9:
-                case 17:
-                    return (0, 4, 8, 12);
-                case 2:
-                case 10:
-                case 18:
-                    return (1, 5, 9, 13);
-                case 3:
-                case 11:
-                case 19:
-                    return (2, 6, 10, 14);
-                case 4:
-                case 12:
-                case 20:
-                    return (3, 7, 11, 15);
-                case 5:
-                case 13:
-                    return (0, 5, 10, 15);
-                case 6:
-                case 14:
-                    return (1, 6, 11, 12);
-                case 7:
-                case 15:
-                    return (2, 7, 8, 13);
-                case 8:
-                case 16:
-                    return (3, 4, 9, 14);
-                default:
-                    Debug.Assert(false, $"No state indices found for round {round}");
-                    return (-1, -1, -1, -1);
-            }
-        }
         private int calculateRoundFromQRIndex(int qrIndex)
         {
             return (int)Math.Floor((double)(qrIndex - 1) / 4) + 1;

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -435,7 +435,7 @@ namespace Cryptool.Plugins.ChaCha
                 case 8:
                     return (3, 4, 9, 14);
                 default:
-                    Debug.Assert(false, string.Format("No state indices found for qrIndex", qrIndex));
+                    Debug.Assert(false, $"No state indices found for qrIndex {qrIndex}");
                     return (-1, -1, -1, -1);
             }
         }
@@ -460,7 +460,7 @@ namespace Cryptool.Plugins.ChaCha
                 case 8:
                     return (3, 4, 9, 14);
                 default:
-                    Debug.Assert(false, string.Format("No state indices found for round", round));
+                    Debug.Assert(false, $"No state indices found for round {round}");
                     return (-1, -1, -1, -1);
             }
         }

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -208,6 +208,10 @@ namespace Cryptool.Plugins.ChaCha
                     pres.Nav.Replace((TextBox)GetIndexElement(pres, "QROutX3", i), qrDetailValues[i - 1, 5]);
                     pres.Nav.Replace((TextBox)GetIndexElement(pres, "QRXOR", i),   qrDetailValues[i - 1, 6]);
                 }
+                pres.Nav.Replace(pres.QROutA, qrOutA);
+                pres.Nav.Replace(pres.QROutB, qrOutB);
+                pres.Nav.Replace(pres.QROutC, qrOutC);
+                pres.Nav.Replace(pres.QROutD, qrOutD);
             });
         }
 

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -149,7 +149,14 @@ namespace Cryptool.Plugins.ChaCha
 
         public static void HideAllQRArrowsExcept(ChaChaPresentation pres, int arrowIndex)
         {
-            Enumerable.Range(1, 8).Select(i => ((TextBox)GetIndexElement(pres, "ArrowQRRound", i)).Visibility = Visibility.Hidden);
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", 1)).Visibility = Visibility.Hidden;
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", 2)).Visibility = Visibility.Hidden;
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", 3)).Visibility = Visibility.Hidden;
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", 4)).Visibility = Visibility.Hidden;
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", 5)).Visibility = Visibility.Hidden;
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", 6)).Visibility = Visibility.Hidden;
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", 7)).Visibility = Visibility.Hidden;
+            ((TextBox)GetIndexElement(pres, "ArrowQRRound", 8)).Visibility = Visibility.Hidden;
             ((TextBox)GetIndexElement(pres, "ArrowQRRound", arrowIndex)).Visibility = Visibility.Visible;
         }
         public static void ClearQRDetail(ChaChaPresentation pres)

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -12,11 +12,105 @@ namespace Cryptool.Plugins.ChaCha
     class KeystreamBlockGenPage : Page
     {
         ChaChaPresentation _pres;
-        public KeystreamBlockGenPage(ContentControl pageElement, ChaChaPresentation pres) : base(pageElement)
+        public KeystreamBlockGenPage(ContentControl pageElement, ChaChaPresentation pres) : base(pageElement, GenerateCache(pres))
         {
             _pres = pres;
             Init();
         }
+
+        private static ActionCache GenerateCache(ChaChaPresentation pres)
+        {
+            CachePageAction GenerateRoundCacheEntry(int round)
+            {
+                CachePageAction cache = new CachePageAction();
+                cache.AddToExec(() =>
+                {
+                    ClearQRDetail(pres);
+                    // update state matrix
+                    TextBox[] stateTextBoxes = GetStateTextBoxes(pres);
+                    uint[] stateEntries = pres.GetResult(ResultType.CHACHA_HASH_ROUND, round - 1);
+                    Debug.Assert(stateTextBoxes.Length == stateEntries.Length);
+                    for (int x = 0; x < stateEntries.Length; ++x)
+                    {
+                        stateTextBoxes[x].Text = ChaChaPresentation.HexString(stateEntries[x]);
+                    }
+                    // highlight only diagonal state entries because they will be copied into QR detail in next action
+                    (int i, int j, int k, int l) = round % 2 == 1 ? (0, 4, 8, 12) : (0, 5, 10, 15);
+                    UnmarkAllStateEntriesExcept(pres, i, j, k, l);
+                    // update round indicator
+                    pres.CurrentRoundIndex = round;
+                    pres.Nav.Replace(pres.CurrentRound, round.ToString());
+                    // hide all QR arrows except the one for the round
+                    int qrIndex = round % 2 == 1 ? 1 : 5;
+                    HideAllQRArrowsExcept(pres, qrIndex);
+                });
+                return cache;
+            }
+            // Cache entry for action index: 3 - "Round 1"
+            CachePageAction cache3 = GenerateRoundCacheEntry(1);
+            // Cache entry for action index: 283 - "Round 2"
+            CachePageAction cache283 = GenerateRoundCacheEntry(2);
+            // Cache entry for action index: 563 - "Round 3"
+            CachePageAction cache563 = GenerateRoundCacheEntry(3);
+            // Cache entry for action index: 843 - "Round 4"
+            CachePageAction cache843 = GenerateRoundCacheEntry(4);
+            // Cache entry for action index: 1123 - "Round 5"
+            CachePageAction cache1123 = GenerateRoundCacheEntry(5);
+            // Cache entry for action index: 1403 - "Round 6"
+            CachePageAction cache1403 = GenerateRoundCacheEntry(6);
+            // Cache entry for action index: 1683 - "Round 7"
+            CachePageAction cache1683 = GenerateRoundCacheEntry(7);
+            // Cache entry for action index: 1963 - "Round 8"
+            CachePageAction cache1963 = GenerateRoundCacheEntry(8);
+            // Cache entry for action index: 2243 - "Round 9"
+            CachePageAction cache2243 = GenerateRoundCacheEntry(9);
+            // Cache entry for action index: 2523 - "Round 10"
+            CachePageAction cache2523 = GenerateRoundCacheEntry(10);
+            // Cache entry for action index: 2803 - "Round 11"
+            CachePageAction cache2803 = GenerateRoundCacheEntry(11);
+            // Cache entry for action index: 3083 - "Round 12"
+            CachePageAction cache3083 = GenerateRoundCacheEntry(12);
+            // Cache entry for action index: 3363 - "Round 13"
+            CachePageAction cache3363 = GenerateRoundCacheEntry(13);
+            // Cache entry for action index: 3643 - "Round 14"
+            CachePageAction cache3643 = GenerateRoundCacheEntry(14);
+            // Cache entry for action index: 3923 - "Round 15"
+            CachePageAction cache3923 = GenerateRoundCacheEntry(15);
+            // Cache entry for action index: 4203 - "Round 16"
+            CachePageAction cache4203 = GenerateRoundCacheEntry(16);
+            // Cache entry for action index: 4483 - "Round 17"
+            CachePageAction cache4483 = GenerateRoundCacheEntry(17);
+            // Cache entry for action index: 4763 - "Round 18"
+            CachePageAction cache4763 = GenerateRoundCacheEntry(18);
+            // Cache entry for action index: 5043 - "Round 19"
+            CachePageAction cache5043 = GenerateRoundCacheEntry(19);
+            // Cache entry for action index: 5323 - "Round 20"
+            CachePageAction cache5323 = GenerateRoundCacheEntry(20);
+            return new ActionCache(new Dictionary<int, CachePageAction>
+            {
+                { 3, cache3 },
+                { 283, cache283 },
+                { 563, cache563 },
+                { 843, cache843 },
+                { 1123, cache1123 },
+                { 1403, cache1403 },
+                { 1683, cache1683 },
+                { 1963, cache1963 },
+                { 2243, cache2243 },
+                { 2523, cache2523 },
+                { 2803, cache2803 },
+                { 3083, cache3083 },
+                { 3363, cache3363 },
+                { 3643, cache3643 },
+                { 3923, cache3923 },
+                { 4203, cache4203 },
+                { 4483, cache4483 },
+                { 4763, cache4763 },
+                { 5043, cache5043 },
+                { 5323, cache5323 }
+            });
+        }
+
         private void AddToState(
                 string state0, string state1, string state2, string state3,
                 string state4, string state5, string state6, string state7,

--- a/ChaCha/Visualization/Pages/Page.cs
+++ b/ChaCha/Visualization/Pages/Page.cs
@@ -6,7 +6,7 @@ namespace Cryptool.Plugins.ChaCha
 {
     partial class Page
     {
-        private Page(ContentControl pageElement)
+        private protected Page(ContentControl pageElement)
         {
             _page = pageElement;
         }

--- a/ChaCha/Visualization/Pages/Page.cs
+++ b/ChaCha/Visualization/Pages/Page.cs
@@ -6,14 +6,22 @@ namespace Cryptool.Plugins.ChaCha
 {
     partial class Page
     {
+        private protected Page(ContentControl pageElement, ActionCache cache)
+        {
+            _page = pageElement;
+            Cache = cache;
+        }
         private protected Page(ContentControl pageElement)
         {
             _page = pageElement;
+            Cache = ActionCache.Empty;
         }
         // the visual tree element which contains the page - the Visibility of this element will be set to Collapsed / Visible when going to next / previous page.
         private readonly ContentControl _page;
         private readonly List<PageAction> _pageActions = new List<PageAction>();
         private readonly List<PageAction> _pageInitActions = new List<PageAction>();
+
+        public ActionCache Cache { get; }
         public int ActionFrames => _pageActions.Count;
 
         public PageAction[] Actions => _pageActions.ToArray();

--- a/ChaCha/Visualization/Pages/PageAction.cs
+++ b/ChaCha/Visualization/Pages/PageAction.cs
@@ -21,7 +21,7 @@ namespace Cryptool.Plugins.ChaCha
                 a();
             }
         }
-        public void Undo()
+        public virtual void Undo()
         {
             foreach (Action a in _undo)
             {

--- a/ChaCha/Visualization/Pages/StateMatrixPage.cs
+++ b/ChaCha/Visualization/Pages/StateMatrixPage.cs
@@ -74,10 +74,10 @@ namespace Cryptool.Plugins.ChaCha
                 pres.Nav.Replace(pres.UITransformLittleEndian1, le1);
                 pres.Nav.Replace(pres.UITransformLittleEndian2, le2);
                 pres.Nav.Replace(pres.UITransformLittleEndian3, le3);
-                pres.Nav.Replace(pres.UITransformLittleEndian0, le4);
-                pres.Nav.Replace(pres.UITransformLittleEndian1, le5);
-                pres.Nav.Replace(pres.UITransformLittleEndian2, le6);
-                pres.Nav.Replace(pres.UITransformLittleEndian3, le7);
+                pres.Nav.Replace(pres.UITransformLittleEndian4, le4);
+                pres.Nav.Replace(pres.UITransformLittleEndian5, le5);
+                pres.Nav.Replace(pres.UITransformLittleEndian6, le6);
+                pres.Nav.Replace(pres.UITransformLittleEndian7, le7);
             }
             void ClearTransformLittleEndian()
             {

--- a/ChaCha/Visualization/Pages/StateMatrixPage.cs
+++ b/ChaCha/Visualization/Pages/StateMatrixPage.cs
@@ -207,9 +207,8 @@ namespace Cryptool.Plugins.ChaCha
                 MakeLastBoldInDescription();
                 ClearTransformInput();
             });
-            PageAction ivChunksAction = new PageAction(() =>
+            void ReplaceTransformChunkIV()
             {
-                ReplaceTransformChunk(pres.IVChunks[0], pres.IVChunks[1]);
                 if (versionIsDJB)
                 {
                     ReplaceTransformChunk(pres.IVChunks[0], pres.IVChunks[1]);
@@ -218,13 +217,17 @@ namespace Cryptool.Plugins.ChaCha
                 {
                     ReplaceTransformChunk(pres.IVChunks[0], pres.IVChunks[1], pres.IVChunks[2]);
                 }
+            }
+            PageAction ivChunksAction = new PageAction(() =>
+            {
+                ReplaceTransformChunkIV();
             }, () =>
             {
                 ClearTransformChunk();
             });
-            PageAction ivLittleEndianAction = new PageAction(() =>
+            void ReplaceTransformLittleEndianIV()
             {
-                if(versionIsDJB)
+                if (versionIsDJB)
                 {
                     ReplaceTransformLittleEndian(pres.IVLittleEndian[0], pres.IVLittleEndian[1]);
                 }
@@ -232,6 +235,10 @@ namespace Cryptool.Plugins.ChaCha
                 {
                     ReplaceTransformLittleEndian(pres.IVLittleEndian[0], pres.IVLittleEndian[1], pres.IVLittleEndian[2]);
                 }
+            }
+            PageAction ivLittleEndianAction = new PageAction(() =>
+            {
+                ReplaceTransformLittleEndianIV();
             }, () =>
             {
                 ClearTransformLittleEndian();
@@ -261,6 +268,9 @@ namespace Cryptool.Plugins.ChaCha
             }, () =>
             {
                 RemoveLastFromDescription();
+                ReplaceTransformInput(pres.HexInputIV);
+                ReplaceTransformChunkIV();
+                ReplaceTransformLittleEndianIV();
             });
             PageAction counterInputAction = new PageAction(() =>
             {

--- a/ChaCha/Visualization/Pages/StateMatrixPage.cs
+++ b/ChaCha/Visualization/Pages/StateMatrixPage.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Controls;
+﻿using System.Runtime.InteropServices;
+using System.Windows.Controls;
+using System.Windows.Navigation;
 
 namespace Cryptool.Plugins.ChaCha
 {
@@ -9,34 +11,120 @@ namespace Cryptool.Plugins.ChaCha
             bool versionIsDJB = pres.Version == ChaCha.Version.DJB;
             bool keyIs32Byte = pres.InputKey.Length == 32;
             Page page = new Page(pres.UIStateMatrixPage);
+            string STATE_MATRIX_DESCRIPTION_1 = "The 512-bit (128-byte) ChaCha state can be interpreted as a 4x4 matrix, where each entry consists of 4 bytes interpreted as little-endian. The first 16 bytes consist of the constants. ";
+            string STATE_MATRIX_DESCRIPTION_2 = "The next 32 bytes consist of the key. If the key consists of only 16 bytes, it is concatenated with itself. ";
+            string STATE_MATRIX_DESCRIPTION_3 = string.Format(
+                    "The last 16 bytes consist of the counter and the IV (in this order). Since the IV may vary between 8 and 12 bytes, the counter may vary between 8 and 4 bytes. You have chosen a {0}-byte IV. ", pres.InputIV.Length
+                ) + "First, we add the IV to the state. ";
+            string STATE_MATRIX_DESCRIPTION_4 = "And then the counter. Since this is our first keystream block, we set the counter to 0. ";
+            string STATE_MATRIX_DESCRIPTION_5 = "On the next page, we will use this initialized state matrix to generate the first keystream block.";
+            void AddBoldToDescription(string descToAdd)
+            {
+                pres.Nav.AddBold(pres.UIStateMatrixStepDescription, descToAdd);
+            }
+            void ClearDescription()
+            {
+                pres.Nav.Clear(pres.UIStateMatrixStepDescription);
+            }
+            void UnboldLastFromDescription()
+            {
+                pres.Nav.UnboldLast(pres.UIStateMatrixStepDescription);
+            }
+            void MakeLastBoldInDescription()
+            {
+                pres.Nav.MakeBoldLast(pres.UIStateMatrixStepDescription);
+            }
+            void RemoveLastFromDescription()
+            {
+                pres.Nav.RemoveLast(pres.UIStateMatrixStepDescription);
+            }
+            void ReplaceTransformInput(string input)
+            {
+                pres.Nav.Replace(pres.UITransformInput, input);
+            }
+            void ClearTransformInput()
+            {
+                pres.Nav.Clear(pres.UITransformInput);
+            }
+            void ReplaceTransformChunk(string chunk0, string chunk1 = "", string chunk2 = "", string chunk3 = "", string chunk4 = "", string chunk5 = "", string chunk6 = "", string chunk7 = "")
+            {
+                pres.Nav.Replace(pres.UITransformChunk0, chunk0);
+                pres.Nav.Replace(pres.UITransformChunk1, chunk1);
+                pres.Nav.Replace(pres.UITransformChunk2, chunk2);
+                pres.Nav.Replace(pres.UITransformChunk3, chunk3);
+                pres.Nav.Replace(pres.UITransformChunk3, chunk4);
+                pres.Nav.Replace(pres.UITransformChunk3, chunk5);
+                pres.Nav.Replace(pres.UITransformChunk3, chunk6);
+                pres.Nav.Replace(pres.UITransformChunk3, chunk7);
+            }
+            void ClearTransformChunk()
+            {
+                pres.Nav.Clear(pres.UITransformChunk0);
+                pres.Nav.Clear(pres.UITransformChunk1);
+                pres.Nav.Clear(pres.UITransformChunk2);
+                pres.Nav.Clear(pres.UITransformChunk3);
+                pres.Nav.Clear(pres.UITransformChunk4);
+                pres.Nav.Clear(pres.UITransformChunk5);
+                pres.Nav.Clear(pres.UITransformChunk6);
+                pres.Nav.Clear(pres.UITransformChunk7);
+            }
+            void ReplaceTransformLittleEndian(string le0, string le1 = "", string le2 = "", string le3 = "", string le4 = "", string le5 = "", string le6 = "", string le7 = "")
+            {
+                pres.Nav.Replace(pres.UITransformLittleEndian0, le0);
+                pres.Nav.Replace(pres.UITransformLittleEndian1, le1);
+                pres.Nav.Replace(pres.UITransformLittleEndian2, le2);
+                pres.Nav.Replace(pres.UITransformLittleEndian3, le3);
+                pres.Nav.Replace(pres.UITransformLittleEndian0, le4);
+                pres.Nav.Replace(pres.UITransformLittleEndian1, le5);
+                pres.Nav.Replace(pres.UITransformLittleEndian2, le6);
+                pres.Nav.Replace(pres.UITransformLittleEndian3, le7);
+            }
+            void ClearTransformLittleEndian()
+            {
+                pres.Nav.Clear(pres.UITransformLittleEndian0);
+                pres.Nav.Clear(pres.UITransformLittleEndian1);
+                pres.Nav.Clear(pres.UITransformLittleEndian2);
+                pres.Nav.Clear(pres.UITransformLittleEndian3);
+                pres.Nav.Clear(pres.UITransformLittleEndian4);
+                pres.Nav.Clear(pres.UITransformLittleEndian5);
+                pres.Nav.Clear(pres.UITransformLittleEndian6);
+                pres.Nav.Clear(pres.UITransformLittleEndian7);
+            }
             #region constants
             PageAction constantsStepDescriptionAction = new PageAction(() =>
             {
-                string desc = "The 512-bit (128-byte) ChaCha state can be interpreted as a 4x4 matrix, where each entry consists of 4 bytes interpreted as little-endian. The first 16 bytes consist of the constants. ";
-                pres.Nav.AddBold(pres.UIStateMatrixStepDescription, desc);
-            }, pres.Nav.Undo);
+                AddBoldToDescription(STATE_MATRIX_DESCRIPTION_1);
+            }, () =>
+            {
+                ClearDescription();
+            });
             PageAction constantsInputAction = new PageAction(() =>
             {
-                pres.Nav.UnboldLast(pres.UIStateMatrixStepDescription);
-                pres.Nav.Replace(pres.UITransformInput, pres.HexConstants);
-            }, pres.Nav.Undo);
+                UnboldLastFromDescription();
+                ReplaceTransformInput(pres.HexConstants);
+            }, () =>
+            {
+                MakeLastBoldInDescription();
+                ClearTransformInput();
+            });
             PageAction constantsChunksAction = new PageAction(() =>
             {
-                pres.Nav.Replace(pres.UITransformChunk0, pres.ConstantsChunks[0]);
-                pres.Nav.Replace(pres.UITransformChunk1, pres.ConstantsChunks[1]);
-                pres.Nav.Replace(pres.UITransformChunk2, pres.ConstantsChunks[2]);
-                pres.Nav.Replace(pres.UITransformChunk3, pres.ConstantsChunks[3]);
-            }, pres.Nav.Undo);
+                ReplaceTransformChunk(pres.ConstantsChunks[0], pres.ConstantsChunks[1], pres.ConstantsChunks[2], pres.ConstantsChunks[3]);
+            }, () =>
+            {
+                ClearTransformChunk();
+            });
             PageAction constantsLittleEndianAction = new PageAction(() =>
             {
-                pres.Nav.Replace(pres.UITransformLittleEndian0, pres.ConstantsLittleEndian[0]);
-                pres.Nav.Replace(pres.UITransformLittleEndian1, pres.ConstantsLittleEndian[1]);
-                pres.Nav.Replace(pres.UITransformLittleEndian2, pres.ConstantsLittleEndian[2]);
-                pres.Nav.Replace(pres.UITransformLittleEndian3, pres.ConstantsLittleEndian[3]);
-            }, pres.Nav.Undo);
+                ReplaceTransformLittleEndian(pres.ConstantsLittleEndian[0], pres.ConstantsLittleEndian[1], pres.ConstantsLittleEndian[2], pres.ConstantsLittleEndian[3]);
+            }, () =>
+            {
+                ClearTransformLittleEndian();
+            });
             PageAction[] copyConstantsToStateActions = pres.Nav.CopyActions(
                 new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell, pres.UITransformLittleEndian2Cell, pres.UITransformLittleEndian3Cell },
-                new Border[] { pres.UIState0Cell, pres.UIState1Cell, pres.UIState2Cell, pres.UIState3Cell });
+                new Border[] { pres.UIState0Cell, pres.UIState1Cell, pres.UIState2Cell, pres.UIState3Cell },
+                new string[] { "", "", "", "" });
             page.AddAction(constantsStepDescriptionAction);
             page.AddAction(constantsInputAction);
             page.AddAction(constantsChunksAction);
@@ -46,42 +134,48 @@ namespace Cryptool.Plugins.ChaCha
             #region key
             PageAction keyStepDescriptionAction = new PageAction(() =>
             {
-                string desc = "The next 32 bytes consist of the key. If the key consists of only 16 bytes, it is concatenated with itself. ";
-                pres.Nav.AddBold(pres.UIStateMatrixStepDescription, desc);
-                pres.Nav.Clear(pres.UITransformInput);
-                pres.Nav.Clear(pres.UITransformChunk0, pres.UITransformChunk1, pres.UITransformChunk2, pres.UITransformChunk3);
-                pres.Nav.Clear(pres.UITransformLittleEndian0, pres.UITransformLittleEndian1, pres.UITransformLittleEndian2, pres.UITransformLittleEndian3);
-            }, pres.Nav.Undo);
+                AddBoldToDescription(STATE_MATRIX_DESCRIPTION_2);
+                ClearTransformInput();
+                ClearTransformChunk();
+                ClearTransformLittleEndian();
+            }, () =>
+            {
+                RemoveLastFromDescription();
+                ReplaceTransformInput(pres.HexConstants);
+                ReplaceTransformChunk(pres.ConstantsChunks[0], pres.ConstantsChunks[1], pres.ConstantsChunks[2], pres.ConstantsChunks[3]);
+                ReplaceTransformLittleEndian(pres.ConstantsLittleEndian[0], pres.ConstantsLittleEndian[1], pres.ConstantsLittleEndian[2], pres.ConstantsLittleEndian[3]);
+            });
             PageAction keyInputAction = new PageAction(() =>
             {
-                pres.Nav.UnboldLast(pres.UIStateMatrixStepDescription);
-                pres.Nav.Replace(pres.UITransformInput, pres.HexInputKey);
-            }, pres.Nav.Undo);
+                UnboldLastFromDescription();
+                ReplaceTransformInput(pres.HexInputKey);
+            }, () =>
+            {
+                MakeLastBoldInDescription();
+                ClearTransformInput();
+            });
             PageAction keyChunksAction = new PageAction(() =>
             {
-                pres.Nav.Replace(pres.UITransformChunk0, pres.KeyChunks[0]);
-                pres.Nav.Replace(pres.UITransformChunk1, pres.KeyChunks[1]);
-                pres.Nav.Replace(pres.UITransformChunk2, pres.KeyChunks[2]);
-                pres.Nav.Replace(pres.UITransformChunk3, pres.KeyChunks[3]);
-                pres.Nav.Replace(pres.UITransformChunk4, pres.KeyChunks[keyIs32Byte ? 4 : 0]);
-                pres.Nav.Replace(pres.UITransformChunk5, pres.KeyChunks[keyIs32Byte ? 5 : 1]);
-                pres.Nav.Replace(pres.UITransformChunk6, pres.KeyChunks[keyIs32Byte ? 6 : 2]);
-                pres.Nav.Replace(pres.UITransformChunk7, pres.KeyChunks[keyIs32Byte ? 7 : 3]);
-            }, pres.Nav.Undo);
+                ReplaceTransformChunk(
+                    pres.KeyChunks[0],  pres.KeyChunks[1], pres.KeyChunks[2], pres.KeyChunks[3],
+                    pres.KeyChunks[keyIs32Byte ? 4 : 0], pres.KeyChunks[keyIs32Byte ? 5 : 1], pres.KeyChunks[keyIs32Byte ? 6 : 2], pres.KeyChunks[keyIs32Byte ? 7 : 3]);
+            }, () =>
+            {
+                ClearTransformChunk();
+            });
             PageAction keyLittleEndianAction = new PageAction(() =>
             {
-                pres.Nav.Replace(pres.UITransformLittleEndian0, pres.KeyLittleEndian[0]);
-                pres.Nav.Replace(pres.UITransformLittleEndian1, pres.KeyLittleEndian[1]);
-                pres.Nav.Replace(pres.UITransformLittleEndian2, pres.KeyLittleEndian[2]);
-                pres.Nav.Replace(pres.UITransformLittleEndian3, pres.KeyLittleEndian[3]);
-                pres.Nav.Replace(pres.UITransformLittleEndian4, pres.KeyLittleEndian[keyIs32Byte ? 4 : 0]);
-                pres.Nav.Replace(pres.UITransformLittleEndian5, pres.KeyLittleEndian[keyIs32Byte ? 5 : 1]);
-                pres.Nav.Replace(pres.UITransformLittleEndian6, pres.KeyLittleEndian[keyIs32Byte ? 6 : 2]);
-                pres.Nav.Replace(pres.UITransformLittleEndian7, pres.KeyLittleEndian[keyIs32Byte ? 7 : 3]);
-            }, pres.Nav.Undo);
+                ReplaceTransformLittleEndian(
+                    pres.KeyLittleEndian[0], pres.KeyLittleEndian[1], pres.KeyLittleEndian[2], pres.KeyLittleEndian[3],
+                    pres.KeyLittleEndian[keyIs32Byte ? 4 : 0], pres.KeyLittleEndian[keyIs32Byte ? 5 : 1], pres.KeyLittleEndian[keyIs32Byte ? 6 : 2], pres.KeyLittleEndian[keyIs32Byte ? 7 : 3]);
+            }, () =>
+            {
+                ClearTransformLittleEndian();
+            });
             PageAction[] copyKeyToStateActions = pres.Nav.CopyActions(
                 new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell, pres.UITransformLittleEndian2Cell, pres.UITransformLittleEndian3Cell, pres.UITransformLittleEndian4Cell, pres.UITransformLittleEndian5Cell, pres.UITransformLittleEndian6Cell, pres.UITransformLittleEndian7Cell },
-                new Border[] { pres.UIState4Cell, pres.UIState5Cell, pres.UIState6Cell, pres.UIState7Cell, pres.UIState8Cell, pres.UIState9Cell, pres.UIState10Cell, pres.UIState11Cell });
+                new Border[] { pres.UIState4Cell, pres.UIState5Cell, pres.UIState6Cell, pres.UIState7Cell, pres.UIState8Cell, pres.UIState9Cell, pres.UIState10Cell, pres.UIState11Cell },
+                new string[] { "", "", "", ""});
             page.AddAction(keyStepDescriptionAction);
             page.AddAction(keyInputAction);
             page.AddAction(keyChunksAction);
@@ -91,33 +185,66 @@ namespace Cryptool.Plugins.ChaCha
             #region iv
             PageAction ivStepDescriptionAction = new PageAction(() =>
             {
-                string desc = string.Format(
-                    "The last 16 bytes consist of the counter and the IV (in this order). Since the IV may vary between 8 and 12 bytes, the counter may vary between 8 and 4 bytes. You have chosen a {0}-byte IV. ", pres.InputIV.Length
-                ) + "First, we add the IV to the state. ";
-                pres.Nav.AddBold(pres.UIStateMatrixStepDescription, desc);
-                pres.Nav.Clear(pres.UITransformInput);
-                pres.Nav.Clear(pres.UITransformChunk0, pres.UITransformChunk1, pres.UITransformChunk2, pres.UITransformChunk3, pres.UITransformChunk4, pres.UITransformChunk5, pres.UITransformChunk6, pres.UITransformChunk7);
-                pres.Nav.Clear(pres.UITransformLittleEndian0, pres.UITransformLittleEndian1, pres.UITransformLittleEndian2, pres.UITransformLittleEndian3, pres.UITransformLittleEndian4, pres.UITransformLittleEndian5, pres.UITransformLittleEndian6, pres.UITransformLittleEndian7);
-            }, pres.Nav.Undo);
+                AddBoldToDescription(STATE_MATRIX_DESCRIPTION_3);
+                ClearTransformInput();
+                ClearTransformChunk();
+                ClearTransformLittleEndian();
+            }, () =>
+            {
+                RemoveLastFromDescription();
+                ReplaceTransformInput(pres.HexInputKey);
+                ReplaceTransformChunk(pres.KeyChunks[0], pres.KeyChunks[1], pres.KeyChunks[2], pres.KeyChunks[3],
+                    pres.KeyChunks[keyIs32Byte ? 4 : 0], pres.KeyChunks[keyIs32Byte ? 5 : 1], pres.KeyChunks[keyIs32Byte ? 6 : 2], pres.KeyChunks[keyIs32Byte ? 7 : 3]);
+                ReplaceTransformLittleEndian(pres.KeyLittleEndian[0], pres.KeyLittleEndian[1], pres.KeyLittleEndian[2], pres.KeyLittleEndian[3],
+                    pres.KeyLittleEndian[keyIs32Byte ? 4 : 0], pres.KeyLittleEndian[keyIs32Byte ? 5 : 1], pres.KeyLittleEndian[keyIs32Byte ? 6 : 2], pres.KeyLittleEndian[keyIs32Byte ? 7 : 3]);
+            });
             PageAction ivInputAction = new PageAction(() =>
             {
-                pres.Nav.UnboldLast(pres.UIStateMatrixStepDescription);
-                pres.Nav.Replace(pres.UITransformInput, pres.HexInputIV);
-            }, pres.Nav.Undo);
+                UnboldLastFromDescription();
+                ReplaceTransformInput(pres.HexInputIV);
+            }, () =>
+            {
+                MakeLastBoldInDescription();
+                ClearTransformInput();
+            });
             PageAction ivChunksAction = new PageAction(() =>
             {
-                pres.Nav.Replace(pres.UITransformChunk0, pres.IVChunks[0]);
-                pres.Nav.Replace(pres.UITransformChunk1, pres.IVChunks[1]);
-                if(!versionIsDJB) pres.Nav.Replace(pres.UITransformChunk2, pres.IVChunks[2]);
-            }, pres.Nav.Undo);
+                ReplaceTransformChunk(pres.IVChunks[0], pres.IVChunks[1]);
+                if (versionIsDJB)
+                {
+                    ReplaceTransformChunk(pres.IVChunks[0], pres.IVChunks[1]);
+                }
+                else
+                {
+                    ReplaceTransformChunk(pres.IVChunks[0], pres.IVChunks[1], pres.IVChunks[2]);
+                }
+            }, () =>
+            {
+                ClearTransformChunk();
+            });
             PageAction ivLittleEndianAction = new PageAction(() =>
             {
-                pres.Nav.Replace(pres.UITransformLittleEndian0, pres.IVLittleEndian[0]);
-                pres.Nav.Replace(pres.UITransformLittleEndian1, pres.IVLittleEndian[1]);
-                if(!versionIsDJB) pres.Nav.Replace(pres.UITransformLittleEndian2, pres.IVLittleEndian[2]);
-            }, pres.Nav.Undo);
-            PageAction[] copyIVToStateActions = versionIsDJB ? pres.Nav.CopyActions(new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell }, new Border[] { pres.UIState14Cell, pres.UIState15Cell })
-                : pres.Nav.CopyActions(new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell, pres.UITransformLittleEndian2Cell }, new Border[] { pres.UIState13Cell, pres.UIState14Cell, pres.UIState15Cell });
+                if(versionIsDJB)
+                {
+                    ReplaceTransformLittleEndian(pres.IVLittleEndian[0], pres.IVLittleEndian[1]);
+                }
+                else
+                {
+                    ReplaceTransformLittleEndian(pres.IVLittleEndian[0], pres.IVLittleEndian[1], pres.IVLittleEndian[2]);
+                }
+            }, () =>
+            {
+                ClearTransformLittleEndian();
+            });
+            PageAction[] copyIVToStateActions = versionIsDJB ?
+                pres.Nav.CopyActions(
+                    new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell },
+                    new Border[] { pres.UIState14Cell, pres.UIState15Cell },
+                    new string[] { "", "" })
+                : pres.Nav.CopyActions(
+                    new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell, pres.UITransformLittleEndian2Cell },
+                    new Border[] { pres.UIState13Cell, pres.UIState14Cell, pres.UIState15Cell },
+                    new string[] { "", "", "" });
             page.AddAction(ivStepDescriptionAction);
             page.AddAction(ivInputAction);
             page.AddAction(ivChunksAction);
@@ -127,35 +254,60 @@ namespace Cryptool.Plugins.ChaCha
             #region counter
             PageAction counterStepDescriptionAction = new PageAction(() =>
             {
-                string desc = "And then the counter. Since this is our first keystream block, we set the counter to 0. ";
-                pres.Nav.AddBold(pres.UIStateMatrixStepDescription, desc);
-                pres.Nav.Clear(pres.UITransformInput);
-                pres.Nav.Clear(pres.UITransformChunk0, pres.UITransformChunk1, pres.UITransformChunk2, pres.UITransformChunk3);
-                pres.Nav.Clear(pres.UITransformLittleEndian0, pres.UITransformLittleEndian1, pres.UITransformLittleEndian2, pres.UITransformLittleEndian3);
-            }, pres.Nav.Undo);
+                AddBoldToDescription(STATE_MATRIX_DESCRIPTION_4);
+                ClearTransformInput();
+                ClearTransformChunk();
+                ClearTransformLittleEndian();
+            }, () =>
+            {
+                RemoveLastFromDescription();
+            });
             PageAction counterInputAction = new PageAction(() =>
             {
-                pres.Nav.UnboldLast(pres.UIStateMatrixStepDescription);
-                pres.Nav.Replace(pres.UITransformInput, pres.HexInitialCounter);
-            }, pres.Nav.Undo);
+                UnboldLastFromDescription();
+                ReplaceTransformInput(pres.HexInitialCounter);
+            }, () =>
+            {
+                MakeLastBoldInDescription();
+                ClearTransformInput();
+            });
             PageAction counterChunksAction = new PageAction(() =>
             {
-                pres.Nav.Replace(pres.UITransformChunk0, pres.InitialCounterChunks[0]);
                 if(versionIsDJB)
                 {
-                    pres.Nav.Replace(pres.UITransformChunk1, pres.InitialCounterChunks[1]);
+                    ReplaceTransformChunk(pres.InitialCounterChunks[0], pres.InitialCounterChunks[1]);
                 }
-            }, pres.Nav.Undo);
+                else
+                {
+                    ReplaceTransformChunk(pres.InitialCounterChunks[0]);
+                }
+            }, () =>
+            {
+                ClearTransformChunk();
+            });
             PageAction counterLittleEndianAction = new PageAction(() =>
             {
-                pres.Nav.Replace(pres.UITransformLittleEndian0, pres.InitialCounterLittleEndian[0]);
-                if (versionIsDJB)
+                if(versionIsDJB)
                 {
-                    pres.Nav.Replace(pres.UITransformLittleEndian1, pres.InitialCounterLittleEndian[1]);
+                    ReplaceTransformLittleEndian(pres.InitialCounterLittleEndian[0], pres.InitialCounterLittleEndian[1]);
                 }
-            }, pres.Nav.Undo);
-            PageAction[] copyCounterToStateActions = versionIsDJB ? pres.Nav.CopyActions(new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell }, new Border[] { pres.UIState12Cell, pres.UIState13Cell }) :
-                pres.Nav.CopyActions(new Border[] { pres.UITransformLittleEndian0Cell }, new Border[] { pres.UIState12Cell });
+                else
+                {
+                    ReplaceTransformLittleEndian(pres.InitialCounterLittleEndian[0]);
+                }
+            }, () =>
+            {
+                ClearTransformLittleEndian();
+            });
+            PageAction[] copyCounterToStateActions = versionIsDJB ?
+                pres.Nav.CopyActions(
+                    new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell },
+                    new Border[] { pres.UIState12Cell, pres.UIState13Cell },
+                    new string[] { "", "" })
+                : pres.Nav.CopyActions(
+                    new Border[] { pres.UITransformLittleEndian0Cell },
+                    new Border[] { pres.UIState12Cell },
+                    new string[] { "" });
             page.AddAction(counterStepDescriptionAction);
             page.AddAction(counterInputAction);
             page.AddAction(counterChunksAction);
@@ -163,15 +315,34 @@ namespace Cryptool.Plugins.ChaCha
             page.AddAction(copyCounterToStateActions);
             PageAction nextPageDesc = new PageAction(() =>
             {
-                string desc = "On the next page, we will use this initialized state matrix to generate the first keystream block.";
-                pres.Nav.AddBold(pres.UIStateMatrixStepDescription, desc);
-                pres.Nav.Clear(pres.UITransformInput);
-                pres.Nav.Clear(pres.UITransformChunk0, pres.UITransformChunk1, pres.UITransformChunk2, pres.UITransformChunk3);
-                pres.Nav.Clear(pres.UITransformLittleEndian0, pres.UITransformLittleEndian1, pres.UITransformLittleEndian2, pres.UITransformLittleEndian3);
-            }, pres.Nav.Undo);
+                AddBoldToDescription(STATE_MATRIX_DESCRIPTION_5);
+                ClearTransformInput();
+                ClearTransformChunk();
+                ClearTransformLittleEndian();
+            }, () =>
+            {
+                RemoveLastFromDescription();
+                ReplaceTransformInput(pres.HexInitialCounter);
+                if (versionIsDJB)
+                {
+                    ReplaceTransformChunk(pres.InitialCounterChunks[0], pres.InitialCounterChunks[1]);
+                }
+                else
+                {
+                    ReplaceTransformChunk(pres.InitialCounterChunks[0]);
+                }
+                if (versionIsDJB)
+                {
+                    ReplaceTransformLittleEndian(pres.InitialCounterLittleEndian[0], pres.InitialCounterLittleEndian[1]);
+                }
+                else
+                {
+                    ReplaceTransformLittleEndian(pres.InitialCounterLittleEndian[0]);
+                }
+            });
             page.AddAction(nextPageDesc);
             #endregion
-            return page;          
+            return page;
         }
     }
 }

--- a/ChaCha/Visualization/Pages/StateMatrixPage.cs
+++ b/ChaCha/Visualization/Pages/StateMatrixPage.cs
@@ -175,7 +175,7 @@ namespace Cryptool.Plugins.ChaCha
             PageAction[] copyKeyToStateActions = pres.Nav.CopyActions(
                 new Border[] { pres.UITransformLittleEndian0Cell, pres.UITransformLittleEndian1Cell, pres.UITransformLittleEndian2Cell, pres.UITransformLittleEndian3Cell, pres.UITransformLittleEndian4Cell, pres.UITransformLittleEndian5Cell, pres.UITransformLittleEndian6Cell, pres.UITransformLittleEndian7Cell },
                 new Border[] { pres.UIState4Cell, pres.UIState5Cell, pres.UIState6Cell, pres.UIState7Cell, pres.UIState8Cell, pres.UIState9Cell, pres.UIState10Cell, pres.UIState11Cell },
-                new string[] { "", "", "", ""});
+                new string[] { "", "", "", "", "", "", "", "" });
             page.AddAction(keyStepDescriptionAction);
             page.AddAction(keyInputAction);
             page.AddAction(keyChunksAction);


### PR DESCRIPTION
Close #51 

With "action cache" the following is meant:

The current navigation system works by creating so called page actions for each page. They implement the changes which we to apply to move from the current state to the next state. This means that, mathematically speaking, each page action implementation just consists of the delta between the previous and the next page state.

This further means that if we want to move 200 actions forward, we need to apply the 200 page actions one after another since we only get to the page state at action 200 if we apply all the deltas in the correct order.

The cache now works by saving the full state of a page at a given action index (cache index) so that when the user wants to move to that action, we can just update all UI elements such that the page state is the same as if we would have applied the 200 page actions one after another. This could probably most easily be done by clearing the state of all UI fields and then setting them appropriately.

To improve performance not only when the user wants to go to an action which happens to be cached, every action move will check if it would cost less moves if we first jump to a cached action and then move from there to the desired action.