### PR TITLE
Navigation Bar v3?

### DIFF
--- a/ChaCha/Visualization/ChaChaPresentation.xaml
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml
@@ -54,14 +54,13 @@
         </Grid.RowDefinitions>
         <Grid Grid.Row="1">
           <Grid.ColumnDefinitions>
-            <ColumnDefinition/>
-            <ColumnDefinition/>
-            <ColumnDefinition/>
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="4*"/>
           </Grid.ColumnDefinitions>
-          <StackPanel Margin="1" Name="PageNavBar" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Center">
+          <StackPanel Margin="1" Name="PageNavBar" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left">
             <!-- Page click handlers are inserted here in code-behind -->
           </StackPanel>
-          <StackPanel Margin="1" Name="ActionNavBar" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Center">
+          <StackPanel Margin="1" Name="ActionNavBar" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
             <!-- Action click handlers are inserted here in code-behind -->
           </StackPanel>
         </Grid>

--- a/ChaCha/Visualization/ChaChaPresentation.xaml
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml
@@ -161,181 +161,176 @@
             <ColumnDefinition Width="1.34*"/>
             <ColumnDefinition Width="2*"/>
           </Grid.ColumnDefinitions>
-          <Grid Grid.Column="0">
-            <Grid>
-              <Grid.RowDefinitions>
-                <RowDefinition Height="1.18*"/>
-                <RowDefinition></RowDefinition>
-              </Grid.RowDefinitions>
-              <!-- State matrix -->
-              <Grid Grid.Row="0">
-                <Border BorderBrush="Black" BorderThickness="0,1,1,0">
-                  <Grid>
-                    <Grid.ColumnDefinitions>
-                      <ColumnDefinition></ColumnDefinition>
-                      <ColumnDefinition></ColumnDefinition>
-                      <ColumnDefinition></ColumnDefinition>
-                      <ColumnDefinition></ColumnDefinition>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                      <RowDefinition></RowDefinition>
-                      <RowDefinition></RowDefinition>
-                      <RowDefinition></RowDefinition>
-                      <RowDefinition></RowDefinition>
-                    </Grid.RowDefinitions>
-                    <!-- Row 0 -->
-                    <Border Grid.Row="0" Grid.Column="0" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState0Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState0"/>
-                    </Border>
-                    <Border Grid.Row="0" Grid.Column="1" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState1Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState1"/>
-                    </Border>
-                    <Border Grid.Row="0" Grid.Column="2" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState2Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState2"/>
-                    </Border>
-                    <Border Grid.Row="0" Grid.Column="3" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState3Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState3"/>
-                    </Border>
-                    <!-- Row 1 -->
-                    <Border Grid.Row="1" Grid.Column="0" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState4Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState4"/>
-                    </Border>
-                    <Border Grid.Row="1" Grid.Column="1" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState5Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState5"/>
-                    </Border>
-                    <Border Grid.Row="1" Grid.Column="2" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState6Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState6"/>
-                    </Border>
-                    <Border Grid.Row="1" Grid.Column="3" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState7Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState7"/>
-                    </Border>
-                    <!-- Row 2 -->
-                    <Border Grid.Row="2" Grid.Column="0" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState8Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState8"/>
-                    </Border>
-                    <Border Grid.Row="2" Grid.Column="1" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState9Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState9"/>
-                    </Border>
-                    <Border Grid.Row="2" Grid.Column="2" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState10Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState10"/>
-                    </Border>
-                    <Border Grid.Row="2" Grid.Column="3" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState11Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState11"/>
-                    </Border>
-                    <!-- Row 3 -->
-                    <Border Grid.Row="3" Grid.Column="0" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState12Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState12"/>
-                    </Border>
-                    <Border Grid.Row="3" Grid.Column="1" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState13Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState13"/>
-                    </Border>
-                    <Border Grid.Row="3" Grid.Column="2" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState14Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState14"/>
-                    </Border>
-                    <Border Grid.Row="3" Grid.Column="3" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState15Cell">
-                      <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState15"/>
-                    </Border>
-                  </Grid>
-                </Border>
-              </Grid>
-              <!-- little-endian transformation -->
-              <Grid Margin="10" Grid.Row="1">
+          <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+          </Grid.RowDefinitions>
+          <!-- State matrix -->
+          <Grid Grid.Row="0" Grid.Column="0">
+            <Border BorderBrush="Black" BorderThickness="0,1,1,0">
+              <Grid>
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition></ColumnDefinition>
+                  <ColumnDefinition></ColumnDefinition>
+                  <ColumnDefinition></ColumnDefinition>
+                  <ColumnDefinition></ColumnDefinition>
+                </Grid.ColumnDefinitions>
                 <Grid.RowDefinitions>
                   <RowDefinition></RowDefinition>
                   <RowDefinition></RowDefinition>
                   <RowDefinition></RowDefinition>
+                  <RowDefinition></RowDefinition>
                 </Grid.RowDefinitions>
-                <Grid.ColumnDefinitions>
-                  <ColumnDefinition></ColumnDefinition>
-                  <ColumnDefinition></ColumnDefinition>
-                </Grid.ColumnDefinitions>
-                <TextBox Grid.Row="0" Grid.Column="0">
-                  Input:
-                </TextBox>
-                <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource hexTextBox}" Name="UITransformInput"/>
-                <TextBox Grid.Row="1" Grid.Column="0">
-                  Split into 4 byte chunks:
-                </TextBox>
-                <UniformGrid Grid.Column="1" Grid.Row="1" Rows="2" Columns="4">
-                  <Border Grid.Row="0" Grid.Column="0">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk0"/>
-                  </Border>
-                  <Border Grid.Row="0" Grid.Column="1">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk1"/>
-                  </Border>
-                  <Border Grid.Row="0" Grid.Column="2">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk2"/>
-                  </Border>
-                  <Border Grid.Row="0" Grid.Column="3">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center"  Style="{StaticResource hexTextBox}" Name="UITransformChunk3"/>
-                  </Border>
-                  <Border Grid.Row="1" Grid.Column="0">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk4"/>
-                  </Border>
-                  <Border Grid.Row="1" Grid.Column="1">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk5"/>
-                  </Border>
-                  <Border Grid.Row="1" Grid.Column="2">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk6"/>
-                  </Border>
-                  <Border Grid.Row="1" Grid.Column="3">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk7"/>
-                  </Border>
-                </UniformGrid>
-                <TextBox Grid.Row="2" Grid.Column="0">
-                  Transform each chunk into little-endian:
-                </TextBox>
-                <UniformGrid Grid.Row="2" Grid.Column="1" Rows="2" Columns="4">
-                  <Border Grid.Row="0" Grid.Column="0" Name="UITransformLittleEndian0Cell">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian0"/>
-                  </Border>
-                  <Border Grid.Row="0" Grid.Column="1" Name="UITransformLittleEndian1Cell">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian1"/>
-                  </Border>
-                  <Border Grid.Row="0" Grid.Column="2" Name="UITransformLittleEndian2Cell">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian2"/>
-                  </Border>
-                  <Border Grid.Row="0" Grid.Column="3" Name="UITransformLittleEndian3Cell">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian3"/>
-                  </Border>
-
-                  <Border Grid.Row="1" Grid.Column="0" Name="UITransformLittleEndian4Cell">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian4"/>
-                  </Border>
-                  <Border Grid.Row="1" Grid.Column="1" Name="UITransformLittleEndian5Cell">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian5"/>
-                  </Border>
-                  <Border Grid.Row="1" Grid.Column="2" Name="UITransformLittleEndian6Cell">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian6"/>
-                  </Border>
-                  <Border Grid.Row="1" Grid.Column="3" Name="UITransformLittleEndian7Cell">
-                    <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian7"/>
-                  </Border>
-                </UniformGrid>
+                <!-- Row 0 -->
+                <Border Grid.Row="0" Grid.Column="0" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState0Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState0"/>
+                </Border>
+                <Border Grid.Row="0" Grid.Column="1" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState1Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState1"/>
+                </Border>
+                <Border Grid.Row="0" Grid.Column="2" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState2Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState2"/>
+                </Border>
+                <Border Grid.Row="0" Grid.Column="3" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState3Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState3"/>
+                </Border>
+                <!-- Row 1 -->
+                <Border Grid.Row="1" Grid.Column="0" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState4Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState4"/>
+                </Border>
+                <Border Grid.Row="1" Grid.Column="1" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState5Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState5"/>
+                </Border>
+                <Border Grid.Row="1" Grid.Column="2" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState6Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState6"/>
+                </Border>
+                <Border Grid.Row="1" Grid.Column="3" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState7Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState7"/>
+                </Border>
+                <!-- Row 2 -->
+                <Border Grid.Row="2" Grid.Column="0" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState8Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState8"/>
+                </Border>
+                <Border Grid.Row="2" Grid.Column="1" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState9Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState9"/>
+                </Border>
+                <Border Grid.Row="2" Grid.Column="2" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState10Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState10"/>
+                </Border>
+                <Border Grid.Row="2" Grid.Column="3" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState11Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState11"/>
+                </Border>
+                <!-- Row 3 -->
+                <Border Grid.Row="3" Grid.Column="0" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState12Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState12"/>
+                </Border>
+                <Border Grid.Row="3" Grid.Column="1" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState13Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState13"/>
+                </Border>
+                <Border Grid.Row="3" Grid.Column="2" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState14Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState14"/>
+                </Border>
+                <Border Grid.Row="3" Grid.Column="3" BorderBrush="Black" BorderThickness="1,0,0,1" Name="UIState15Cell">
+                  <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UIState15"/>
+                </Border>
               </Grid>
-            </Grid>
+            </Border>
           </Grid>
-          <Grid Margin="100,0,0,0" Grid.Column="1">
+          <!-- little-endian transformation -->
+          <Grid Grid.Row="1" Grid.Column="0" Margin="10">
             <Grid.RowDefinitions>
-              <RowDefinition Height="14*"></RowDefinition>
+              <RowDefinition></RowDefinition>
+              <RowDefinition></RowDefinition>
+              <RowDefinition></RowDefinition>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition></ColumnDefinition>
+              <ColumnDefinition></ColumnDefinition>
+            </Grid.ColumnDefinitions>
+            <TextBox Grid.Row="0" Grid.Column="0">
+              Input:
+            </TextBox>
+            <TextBox Grid.Row="0" Grid.Column="1" Style="{StaticResource hexTextBox}" Name="UITransformInput"/>
+            <TextBox Grid.Row="1" Grid.Column="0">
+              Split into 4 byte chunks:
+            </TextBox>
+            <UniformGrid Grid.Column="1" Grid.Row="1" Rows="2" Columns="4">
+              <Border Grid.Row="0" Grid.Column="0">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk0"/>
+              </Border>
+              <Border Grid.Row="0" Grid.Column="1">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk1"/>
+              </Border>
+              <Border Grid.Row="0" Grid.Column="2">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk2"/>
+              </Border>
+              <Border Grid.Row="0" Grid.Column="3">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center"  Style="{StaticResource hexTextBox}" Name="UITransformChunk3"/>
+              </Border>
+              <Border Grid.Row="1" Grid.Column="0">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk4"/>
+              </Border>
+              <Border Grid.Row="1" Grid.Column="1">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk5"/>
+              </Border>
+              <Border Grid.Row="1" Grid.Column="2">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk6"/>
+              </Border>
+              <Border Grid.Row="1" Grid.Column="3">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{StaticResource hexTextBox}" Name="UITransformChunk7"/>
+              </Border>
+            </UniformGrid>
+            <TextBox Grid.Row="2" Grid.Column="0">
+              Transform each chunk into little-endian:
+            </TextBox>
+            <UniformGrid Grid.Row="2" Grid.Column="1" Rows="2" Columns="4">
+              <Border Grid.Row="0" Grid.Column="0" Name="UITransformLittleEndian0Cell">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian0"/>
+              </Border>
+              <Border Grid.Row="0" Grid.Column="1" Name="UITransformLittleEndian1Cell">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian1"/>
+              </Border>
+              <Border Grid.Row="0" Grid.Column="2" Name="UITransformLittleEndian2Cell">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian2"/>
+              </Border>
+              <Border Grid.Row="0" Grid.Column="3" Name="UITransformLittleEndian3Cell">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian3"/>
+              </Border>
+
+              <Border Grid.Row="1" Grid.Column="0" Name="UITransformLittleEndian4Cell">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian4"/>
+              </Border>
+              <Border Grid.Row="1" Grid.Column="1" Name="UITransformLittleEndian5Cell">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian5"/>
+              </Border>
+              <Border Grid.Row="1" Grid.Column="2" Name="UITransformLittleEndian6Cell">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian6"/>
+              </Border>
+              <Border Grid.Row="1" Grid.Column="3" Name="UITransformLittleEndian7Cell">
+                <TextBox HorizontalAlignment="Center" VerticalAlignment="Center" Style="{ StaticResource hexTextBox}" Name="UITransformLittleEndian7"/>
+              </Border>
+            </UniformGrid>
+          </Grid>
+          <!-- Step description -->
+          <RichTextBox Margin="100,0,0,0" Grid.Column="1" Grid.Row="0" Name="UIStateMatrixStepDescription"/>
+          <Grid Margin="100,0,0,0" Grid.Column="1" Grid.Row="1">
+            <Grid.RowDefinitions>
               <RowDefinition Height="2*"></RowDefinition>
               <RowDefinition Height="4*"></RowDefinition>
               <RowDefinition Height="4*"></RowDefinition>
               <RowDefinition Height="4*"></RowDefinition>
             </Grid.RowDefinitions>
-            <!-- Step description -->
-            <RichTextBox Name="UIStateMatrixStepDescription"/>
             <!-- state parameters -->
-            <TextBox Grid.Row="1" HorizontalAlignment="Center">State parameters</TextBox>
-            <StackPanel Grid.Row="2" Orientation="Horizontal">
+            <TextBox Grid.Row="0" HorizontalAlignment="Center">State parameters</TextBox>
+            <StackPanel Grid.Row="1" Orientation="Horizontal">
               <TextBox>Constant:</TextBox>
               <TextBox Style="{StaticResource hexTextBox}" Text="{ Binding HexConstants, Mode=OneWay }" Name="UIConstant"/>
             </StackPanel>
-            <StackPanel Grid.Row="3" Orientation="Horizontal">
+            <StackPanel Grid.Row="2" Orientation="Horizontal">
               <TextBox>Key:</TextBox>
               <TextBox Style="{StaticResource hexTextBox}" Text="{ Binding HexInputKey, Mode=OneWay }" Name="UIInputKey"/>
             </StackPanel>
-            <StackPanel Grid.Row="4" Orientation="Horizontal">
+            <StackPanel Grid.Row="3" Orientation="Horizontal">
               <TextBox>Initialization vector (IV):</TextBox>
               <TextBox Style="{StaticResource hexTextBox}" Text="{ Binding HexInputIV, Mode=OneWay }" Name="UIInputIV"/>
             </StackPanel>
@@ -369,7 +364,7 @@
             <ColumnDefinition Width="1.6*"/>
           </Grid.ColumnDefinitions>
           <Grid.RowDefinitions>
-            <RowDefinition Height="1.18*"/>
+            <RowDefinition/>
             <RowDefinition/>
           </Grid.RowDefinitions>
           <!-- State matrix -->

--- a/ChaCha/Visualization/ChaChaPresentation.xaml
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml
@@ -53,14 +53,15 @@
           <RowDefinition Height="8*"/>
         </Grid.RowDefinitions>
         <Grid Grid.Row="1">
-          <Grid.RowDefinitions>
-            <RowDefinition/>
-            <RowDefinition/>
-          </Grid.RowDefinitions>
-          <StackPanel Margin="1" Name="PageNavBar" Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Center">
+          <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+          </Grid.ColumnDefinitions>
+          <StackPanel Margin="1" Name="PageNavBar" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Center">
             <!-- Page click handlers are inserted here in code-behind -->
           </StackPanel>
-          <StackPanel Margin="1" Name="ActionNavBar" Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Center">
+          <StackPanel Margin="1" Name="ActionNavBar" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Center">
             <!-- Action click handlers are inserted here in code-behind -->
           </StackPanel>
         </Grid>
@@ -72,30 +73,6 @@
   </UserControl.Resources>
   <!-- Main grid for content pane -->
   <Grid Name="UIContentPane">
-    <Canvas Margin="5" Panel.ZIndex="5">
-      <Button Height="20" Name="NavigationButton" Click="ToggleNavigationMenu" IsEnabled="{ Binding NavigationEnabled }">
-        Navigation
-      </Button>
-      <Border Canvas.Top="20" BorderThickness="1.5" BorderBrush="Black" Width="600" Visibility="Visible" Name="NavigationMenu" Opacity="0.8" Background="White">
-        <Grid>
-          <Grid.RowDefinitions>
-            <RowDefinition/>
-            <RowDefinition/>
-            <RowDefinition/>
-            <RowDefinition/>
-            <RowDefinition/>
-          </Grid.RowDefinitions>
-          <Button Grid.Row="0" Margin="5" Width="32" Height="18.75" HorizontalAlignment="Left" Name="PageButton_Start">Start</Button>
-          <Button Grid.Row="1" Margin="5" Width="64" Height="18.75" HorizontalAlignment="Left" Name="PageButton_Overview">Overview</Button>
-          <Button Grid.Row="2" Margin="5" Width="160" Height="18.75" HorizontalAlignment="Left" Name="PageButton_StateMatrixInitialization">State Matrix Initialization</Button>
-          <StackPanel Grid.Row="3" Margin="5" Orientation="Horizontal">
-            <TextBlock Width="160" Height="18.75" HorizontalAlignment="Center">Keystream Block Generation:</TextBlock>
-            <StackPanel Name="PageButtonPanel_KeystreamBlockGeneration" Orientation="Horizontal">
-            </StackPanel>
-          </StackPanel>
-        </Grid>
-      </Border>
-    </Canvas>
     <!-- Landing page -->
     <ContentControl Name="UILandingPage" Visibility="Collapsed" Template="{ StaticResource PageTemplate }">
       <ContentControl.Resources>

--- a/ChaCha/Visualization/ChaChaPresentation.xaml
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml
@@ -143,7 +143,7 @@
       </Grid>
     </ContentControl>
     <!-- ChaCha State matrix page -->
-    <ContentControl Name="UIStateMatrixPage" Visibility="Visible" Template="{ StaticResource PageTemplate }">
+    <ContentControl Name="UIStateMatrixPage" Visibility="Collapsed" Template="{ StaticResource PageTemplate }">
       <Grid>
         <Grid.Resources>
           <Style TargetType="TextBox">
@@ -641,372 +641,378 @@
               <RowDefinition/>
             </Grid.RowDefinitions>
             <!-- Quarterround visualization -->
-            <Viewbox>
-              <Canvas Background="White" Width="1500" Height="160" Grid.Row="1">
-                <Canvas>
-                  <!-- Input cells -->
-                  <Border Width="65" Height="40" Name="QRInACell" BorderBrush="Black" BorderThickness="1" Canvas.Left="00" Canvas.Top="0">
-                    <TextBox Style="{StaticResource hexTextBox}" Name="QRInA" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                  </Border>
-                  <Border Width="65" Height="40" Name="QRInBCell" BorderBrush="Black" BorderThickness="1" Canvas.Left="00" Canvas.Top="60">
-                    <TextBox Style="{StaticResource hexTextBox}" Name="QRInB" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                  </Border>
-                  <Border Width="65" Height="40" Name="QRInCCell" BorderBrush="Black" BorderThickness="1" Canvas.Left="00" Canvas.Top="120">
-                    <TextBox Style="{StaticResource hexTextBox}" Name="QRInC" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                  </Border>
-                  <Border Width="65" Height="40" Name="QRInDCell" BorderBrush="Black" BorderThickness="1" Canvas.Left="00" Canvas.Top="180">
-                    <TextBox Style="{StaticResource hexTextBox}" Name="QRInD" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                  </Border>
-                  <!-- Output cells -->
-                  <Border Width="65" Height="40" Name="QROutACell" Grid.Row="0" Grid.Column="10" BorderBrush="Black" BorderThickness="1" Canvas.Left="1435" Canvas.Top="0">
-                    <TextBox Style="{StaticResource hexTextBox}" Name="QROutA" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                  </Border>
-                  <Border Width="65" Height="40" Name="QROutBCell" Grid.Row="1" Grid.Column="10" BorderBrush="Black" BorderThickness="1" Canvas.Left="1435" Canvas.Top="60">
-                    <TextBox Style="{StaticResource hexTextBox}" Name="QROutB" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                  </Border>
-                  <Border Width="65" Height="40" Name="QROutCCell" Grid.Row="2" Grid.Column="10" BorderBrush="Black" BorderThickness="1" Canvas.Left="1435" Canvas.Top="120">
-                    <TextBox Style="{StaticResource hexTextBox}" Name="QROutC" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                  </Border>
-                  <Border Width="65" Height="40" Name="QROutDCell" Grid.Row="3" Grid.Column="10" BorderBrush="Black" BorderThickness="1" Canvas.Left="1435" Canvas.Top="180">
-                    <TextBox Style="{StaticResource hexTextBox}" Name="QROutD" VerticalAlignment="Center" HorizontalAlignment="Center"/>
-                  </Border>
-                  <!-- General paths (unnamed) -->
-                  <Path Stroke="Black" StrokeThickness="1" Data="M 0,20 h 1370"
+            <Grid Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="3">
+              <Viewbox Height="220">
+                <Canvas Width="1500" Height="220" Grid.Row="1">
+                  <Canvas>
+                    <!-- Input cells -->
+                    <Border Width="65" Height="40" Name="QRInACell" BorderBrush="Black" BorderThickness="1" Canvas.Left="00" Canvas.Top="0">
+                      <TextBox Style="{StaticResource hexTextBox}" Name="QRInA" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Border>
+                    <Border Width="65" Height="40" Name="QRInBCell" BorderBrush="Black" BorderThickness="1" Canvas.Left="00" Canvas.Top="60">
+                      <TextBox Style="{StaticResource hexTextBox}" Name="QRInB" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Border>
+                    <Border Width="65" Height="40" Name="QRInCCell" BorderBrush="Black" BorderThickness="1" Canvas.Left="00" Canvas.Top="120">
+                      <TextBox Style="{StaticResource hexTextBox}" Name="QRInC" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Border>
+                    <Border Width="65" Height="40" Name="QRInDCell" BorderBrush="Black" BorderThickness="1" Canvas.Left="00" Canvas.Top="180">
+                      <TextBox Style="{StaticResource hexTextBox}" Name="QRInD" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Border>
+                    <!-- Output cells -->
+                    <Border Width="65" Height="40" Name="QROutACell" Grid.Row="0" Grid.Column="10" BorderBrush="Black" BorderThickness="1" Canvas.Left="1435" Canvas.Top="0">
+                      <TextBox Style="{StaticResource hexTextBox}" Name="QROutA" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Border>
+                    <Border Width="65" Height="40" Name="QROutBCell" Grid.Row="1" Grid.Column="10" BorderBrush="Black" BorderThickness="1" Canvas.Left="1435" Canvas.Top="60">
+                      <TextBox Style="{StaticResource hexTextBox}" Name="QROutB" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Border>
+                    <Border Width="65" Height="40" Name="QROutCCell" Grid.Row="2" Grid.Column="10" BorderBrush="Black" BorderThickness="1" Canvas.Left="1435" Canvas.Top="120">
+                      <TextBox Style="{StaticResource hexTextBox}" Name="QROutC" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Border>
+                    <Border Width="65" Height="40" Name="QROutDCell" Grid.Row="3" Grid.Column="10" BorderBrush="Black" BorderThickness="1" Canvas.Left="1435" Canvas.Top="180">
+                      <TextBox Style="{StaticResource hexTextBox}" Name="QROutD" VerticalAlignment="Center" HorizontalAlignment="Center"/>
+                    </Border>
+                    <!-- General paths (unnamed) -->
+                    <Path Stroke="Black" StrokeThickness="1" Data="M 0,20 h 1370"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInACell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Data="M 0,20 h 139 c 0 -10 20 -10 20 0 h 648 c 0 -10 20 -10 20 0 H 1370"
+                    <Path Stroke="Black" StrokeThickness="1" Data="M 0,20 h 139 c 0 -10 20 -10 20 0 h 648 c 0 -10 20 -10 20 0 H 1370"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInBCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Blue" StrokeThickness="1" Data="M 0,20 h 55" 
+                    <Path Stroke="Blue" StrokeThickness="1" Data="M 0,20 h 55" 
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInBCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Data="M 0,20 h 139 c 0 -10 20 -10 20 0 h 648 c 0 -10 20 -10 20 0 H 1370"
+                    <Path Stroke="Black" StrokeThickness="1" Data="M 0,20 h 139 c 0 -10 20 -10 20 0 h 648 c 0 -10 20 -10 20 0 H 1370"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInCCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Data="M 0,20 h 1370"
+                    <Path Stroke="Black" StrokeThickness="1" Data="M 0,20 h 1370"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInDCell, Path=(Canvas.Top)}"/>
-                  <!-- Input paths (named) -->
-                  <!-- First box -->
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRAddPath_1" Data="M 0,20 h 50 m 4,0 v 60 h -55 M 60,20 h 20"
+                    <!-- Input paths (named) -->
+                    <!-- First box -->
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRAddPath_1" Data="M 0,20 h 50 m 4,0 v 60 h -55 M 60,20 h 20"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInACell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRXORPath_1" Data="M 0,20 h 140 m 9,-10 v -170 h -10 M 159,20 h 5"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRXORPath_1" Data="M 0,20 h 140 m 9,-10 v -170 h -10 M 159,20 h 5"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInDCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRShiftPath_1" Data="M 229,20 h 5 m 20,0 h 5"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRShiftPath_1" Data="M 229,20 h 5 m 20,0 h 5"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInDCell, Path=(Canvas.Top)}"/>
-                  <!-- Second box -->
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRAddPath_2" Data="M 0,20 h 139 c 0 -10 20 -10 20 0 h 220 m 19,0 h 9 m -19, 0 v 60 h -64"
+                    <!-- Second box -->
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRAddPath_2" Data="M 0,20 h 139 c 0 -10 20 -10 20 0 h 220 m 19,0 h 9 m -19, 0 v 60 h -64"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInCCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRXORPath_2" Data="M 0,20 h 139 c 0 -10 20 -10 20 0 h 314 m 19,0 h 6 m -15,10 v 50 h -10"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRXORPath_2" Data="M 0,20 h 139 c 0 -10 20 -10 20 0 h 314 m 19,0 h 6 m -15,10 v 50 h -10"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInBCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRShiftPath_2" Data="M 563,20 h 5 m 20,0 h 5"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRShiftPath_2" Data="M 563,20 h 5 m 20,0 h 5"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInBCell, Path=(Canvas.Top)}"/>
-                  <!-- Third box -->
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRAddPath_3" Data="M -529,20 H 50 m 4,0 v 60 h -65 M 60,20 h 20"
+                    <!-- Third box -->
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRAddPath_3" Data="M -529,20 H 50 m 4,0 v 60 h -65 M 60,20 h 20"
                         Canvas.Left="733" Canvas.Top="{ Binding ElementName=QRInACell, Path=(Canvas.Top)}" Panel.ZIndex="0"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRXORPath_3" Data="M -344,20 H 140 m 9,-10 v -170 h -10 M 159,20 h 5"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRXORPath_3" Data="M -344,20 H 140 m 9,-10 v -170 h -10 M 159,20 h 5"
                         Canvas.Left="733" Canvas.Top="{ Binding ElementName=QRInDCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRShiftPath_3" Data="M 229,20 h 5 m 20,0 h 5"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRShiftPath_3" Data="M 229,20 h 5 m 20,0 h 5"
                         Canvas.Left="733" Canvas.Top="{ Binding ElementName=QRInDCell, Path=(Canvas.Top)}"/>
-                  <!-- Fourth box -->
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRAddPath_4" Data="M -195,20 H 139 c 0 -10 20 -10 20 0 h 220 m 19,0 h 9 m -19, 0 v 60 h -64"
+                    <!-- Fourth box -->
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRAddPath_4" Data="M -195,20 H 139 c 0 -10 20 -10 20 0 h 220 m 19,0 h 9 m -19, 0 v 60 h -64"
                         Canvas.Left="733" Canvas.Top="{ Binding ElementName=QRInCCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRXORPath_4" Data="M -10,20 H 139 c 0 -10 20 -10 20 0 h 314 m 19,0 h 6 m -15,10 v 50 h -10"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRXORPath_4" Data="M -10,20 H 139 c 0 -10 20 -10 20 0 h 314 m 19,0 h 6 m -15,10 v 50 h -10"
                         Canvas.Left="733" Canvas.Top="{ Binding ElementName=QRInBCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QRShiftPath_4" Data="M 563,20 h 5 m 20,0 h 5"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QRShiftPath_4" Data="M 563,20 h 5 m 20,0 h 5"
                         Canvas.Left="65" Canvas.Top="{ Binding ElementName=QRInBCell, Path=(Canvas.Top)}"/>
-                  <!-- Output paths -->
-                  <Path Stroke="Black" StrokeThickness="1" Name="QROutputPath_A" Data="M 0,20 h 563"
+                    <!-- Output paths -->
+                    <Path Stroke="Black" StrokeThickness="1" Name="QROutputPath_A" Data="M 0,20 h 563"
                         Canvas.Left="872" Canvas.Top="{ Binding ElementName=QRInACell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QROutputPath_B" Data="M 0,20 h 44"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QROutputPath_B" Data="M 0,20 h 44"
                         Canvas.Left="1391" Canvas.Top="{ Binding ElementName=QRInBCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QROutputPath_C" Data="M 0,20 h 229"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QROutputPath_C" Data="M 0,20 h 229"
                         Canvas.Left="1206" Canvas.Top="{ Binding ElementName=QRInCCell, Path=(Canvas.Top)}"/>
-                  <Path Stroke="Black" StrokeThickness="1" Name="QROutputPath_D" Data="M 0,20 h 378"
+                    <Path Stroke="Black" StrokeThickness="1" Name="QROutputPath_D" Data="M 0,20 h 378"
                         Canvas.Left="1057" Canvas.Top="{ Binding ElementName=QRInDCell, Path=(Canvas.Top)}"/>
-                  <!-- Grid for qr detail boxes -->
-                  <Grid Canvas.Left="65" Width="1370" Height="260" Canvas.Top="-20">
-                    <Grid.ColumnDefinitions>
-                      <ColumnDefinition Width="0.0248*"/> <!--  34/1370 = 0.0248 -->
-                      <ColumnDefinition Width="0.2189*"/> <!-- 300/1370 = 0.2189 -->
-                      <ColumnDefinition Width="0.0248*"/>
-                      <ColumnDefinition Width="0.2189*"/>
-                      <ColumnDefinition Width="0.0248*"/>
-                      <ColumnDefinition Width="0.2189*"/>
-                      <ColumnDefinition Width="0.0248*"/>
-                      <ColumnDefinition Width="0.2189*"/>
-                      <ColumnDefinition Width="0.0248*"/>
-                    </Grid.ColumnDefinitions>
-                    <Grid.RowDefinitions>
-                      <RowDefinition/>
-                      <RowDefinition/>
-                      <RowDefinition/>
-                      <RowDefinition/>
-                    </Grid.RowDefinitions>
-                    <Canvas Grid.Column="1" Grid.RowSpan="4">
-                      <Rectangle Stroke="Black" Width="300" Height="260" StrokeThickness="1" />
-                      <Grid>
-                        <Grid.ColumnDefinitions>
-                          <ColumnDefinition Width="75"/> <!-- Width: 300/4 = 75 -->
-                          <ColumnDefinition Width="75"/>
-                          <ColumnDefinition Width="75"/>
-                          <ColumnDefinition Width="75"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                          <RowDefinition Height="10"/>
-                          <RowDefinition Height="60"/> <!-- Height: 260/4 = 65-->
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="10"/>
-                        </Grid.RowDefinitions>
-                        <Canvas Grid.Row="1" Grid.Column="0">
-                          <Rectangle Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRAddCell_1" Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRAdd_1" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRAddCircle_1" Fill="White">
-                            <Path.Data>
-                              <EllipseGeometry Center="21,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <Label Canvas.Top="11" Canvas.Left="10" Width="Auto" FontSize="18" Foreground="{ Binding ElementName=QRAddCircle_1, Path=Stroke}" Content="+"/>
-                        </Canvas>
-                        <Canvas Grid.Row="4" Grid.Column="1">
-                          <Rectangle Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRXORCell_1" Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRXOR_1" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                          <TextBox Canvas.Left="30" Canvas.Top="24" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8" TextAlignment="Center" Foreground="{ Binding ElementName=QRXORCircle_1, Path=Stroke}" Text="XOR"/>
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRXORCircle_1">
-                            <Path.Data>
-                              <EllipseGeometry Center="40,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                        </Canvas>
-                        <Canvas Grid.Row="1" Grid.Column="1">
-                          <Path Canvas.Left="30" Stroke="Black" StrokeThickness="1" Data="M 10,30 v 170"/>
-                        </Canvas>
-                        <Canvas Grid.Row="4" Grid.Column="2">
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRShiftCircle_1" Fill="White">
-                            <Path.Data>
-                              <EllipseGeometry Center="60,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <TextBlock Width="20" Height="20"
+                    <!-- Grid for qr detail boxes -->
+                    <Grid Canvas.Left="65" Width="1370" Height="260" Canvas.Top="-20">
+                      <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="0.0248*"/>
+                        <!--  34/1370 = 0.0248 -->
+                        <ColumnDefinition Width="0.2189*"/>
+                        <!-- 300/1370 = 0.2189 -->
+                        <ColumnDefinition Width="0.0248*"/>
+                        <ColumnDefinition Width="0.2189*"/>
+                        <ColumnDefinition Width="0.0248*"/>
+                        <ColumnDefinition Width="0.2189*"/>
+                        <ColumnDefinition Width="0.0248*"/>
+                        <ColumnDefinition Width="0.2189*"/>
+                        <ColumnDefinition Width="0.0248*"/>
+                      </Grid.ColumnDefinitions>
+                      <Grid.RowDefinitions>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                        <RowDefinition/>
+                      </Grid.RowDefinitions>
+                      <Canvas Grid.Column="1" Grid.RowSpan="4">
+                        <Rectangle Stroke="Black" Width="300" Height="260" StrokeThickness="1" />
+                        <Grid>
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="75"/>
+                            <!-- Width: 300/4 = 75 -->
+                            <ColumnDefinition Width="75"/>
+                            <ColumnDefinition Width="75"/>
+                            <ColumnDefinition Width="75"/>
+                          </Grid.ColumnDefinitions>
+                          <Grid.RowDefinitions>
+                            <RowDefinition Height="10"/>
+                            <RowDefinition Height="60"/>
+                            <!-- Height: 260/4 = 65-->
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="10"/>
+                          </Grid.RowDefinitions>
+                          <Canvas Grid.Row="1" Grid.Column="0">
+                            <Rectangle Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRAddCell_1" Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRAdd_1" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRAddCircle_1" Fill="White">
+                              <Path.Data>
+                                <EllipseGeometry Center="21,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <Label Canvas.Top="11" Canvas.Left="10" Width="Auto" FontSize="18" Foreground="{ Binding ElementName=QRAddCircle_1, Path=Stroke}" Content="+"/>
+                          </Canvas>
+                          <Canvas Grid.Row="4" Grid.Column="1">
+                            <Rectangle Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRXORCell_1" Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRXOR_1" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                            <TextBox Canvas.Left="30" Canvas.Top="24" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8" TextAlignment="Center" Foreground="{ Binding ElementName=QRXORCircle_1, Path=Stroke}" Text="XOR"/>
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRXORCircle_1">
+                              <Path.Data>
+                                <EllipseGeometry Center="40,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                          </Canvas>
+                          <Canvas Grid.Row="1" Grid.Column="1">
+                            <Path Canvas.Left="30" Stroke="Black" StrokeThickness="1" Data="M 10,30 v 170"/>
+                          </Canvas>
+                          <Canvas Grid.Row="4" Grid.Column="2">
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRShiftCircle_1" Fill="White">
+                              <Path.Data>
+                                <EllipseGeometry Center="60,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <TextBlock Width="20" Height="20"
                                      Canvas.Top="24" Canvas.Left="50"
                                      HorizontalAlignment="Center" VerticalAlignment="Center"
                                      FontSize="8"
                                      TextAlignment="Center" Foreground="{ Binding ElementName=QRShiftCircle_1, Path=Stroke}"
                                      Text="&lt;&lt;&lt;"
                           />
-                          <TextBlock FontSize="8" Canvas.Top="39" Canvas.Left="64" Text="16" Foreground="{ Binding ElementName=QRShiftCircle_1, Path=Stroke}"/>
-                          <Rectangle Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRShiftCell_1" Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRShift_1" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                        </Canvas>
-                      </Grid>
-                    </Canvas>
-                    <Canvas Grid.Column="3" Grid.RowSpan="4">
-                      <Rectangle Stroke="Black" Width="300" Height="260" StrokeThickness="1" />
-                      <Grid>
-                        <Grid.ColumnDefinitions>
-                          <ColumnDefinition Width="75"/>
-                          <!-- Width: 300/4 = 75 -->
-                          <ColumnDefinition Width="75"/>
-                          <ColumnDefinition Width="75"/>
-                          <ColumnDefinition Width="75"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                          <RowDefinition Height="10"/>
-                          <RowDefinition Height="60"/>
-                          <!-- Height: 260/4 = 65-->
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="10"/>
-                        </Grid.RowDefinitions>
-                        <Canvas Grid.Row="3" Grid.Column="0">
-                          <Rectangle Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRAddCell_2" Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRAdd_2" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRAddCircle_2" Fill="White">
-                            <Path.Data>
-                              <EllipseGeometry Center="21,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <Label Canvas.Top="11" Canvas.Left="10" Width="Auto" FontSize="18" Foreground="{ Binding ElementName=QRAddCircle_2, Path=Stroke}" Content="+"/>
-                          <Path Stroke="Black" StrokeThickness="1" Data="M 20,40 v 50"/>
-                        </Canvas>
-                        <Canvas Grid.Row="2" Grid.Column="1">
-                          <Rectangle Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRXORCell_2" Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRXOR_2" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                          <TextBox Canvas.Left="30" Canvas.Top="24" Width="20" Height="15" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8" TextAlignment="Center" Foreground="{ Binding ElementName=QRXORCircle_2, Path=Stroke}" Text="XOR"/>
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRXORCircle_2">
-                            <Path.Data>
-                              <EllipseGeometry Center="40,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <Path Stroke="Black" StrokeThickness="1" Data="M 40,40 v 50"/>
-                        </Canvas>
-                        <Canvas Grid.Row="2" Grid.Column="2">
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRShiftCircle_2" Fill="White">
-                            <Path.Data>
-                              <EllipseGeometry Center="60,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <TextBlock Width="20" Height="20"
+                            <TextBlock FontSize="8" Canvas.Top="39" Canvas.Left="64" Text="16" Foreground="{ Binding ElementName=QRShiftCircle_1, Path=Stroke}"/>
+                            <Rectangle Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRShiftCell_1" Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRShift_1" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                          </Canvas>
+                        </Grid>
+                      </Canvas>
+                      <Canvas Grid.Column="3" Grid.RowSpan="4">
+                        <Rectangle Stroke="Black" Width="300" Height="260" StrokeThickness="1" />
+                        <Grid>
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="75"/>
+                            <!-- Width: 300/4 = 75 -->
+                            <ColumnDefinition Width="75"/>
+                            <ColumnDefinition Width="75"/>
+                            <ColumnDefinition Width="75"/>
+                          </Grid.ColumnDefinitions>
+                          <Grid.RowDefinitions>
+                            <RowDefinition Height="10"/>
+                            <RowDefinition Height="60"/>
+                            <!-- Height: 260/4 = 65-->
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="10"/>
+                          </Grid.RowDefinitions>
+                          <Canvas Grid.Row="3" Grid.Column="0">
+                            <Rectangle Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRAddCell_2" Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRAdd_2" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRAddCircle_2" Fill="White">
+                              <Path.Data>
+                                <EllipseGeometry Center="21,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <Label Canvas.Top="11" Canvas.Left="10" Width="Auto" FontSize="18" Foreground="{ Binding ElementName=QRAddCircle_2, Path=Stroke}" Content="+"/>
+                            <Path Stroke="Black" StrokeThickness="1" Data="M 20,40 v 50"/>
+                          </Canvas>
+                          <Canvas Grid.Row="2" Grid.Column="1">
+                            <Rectangle Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRXORCell_2" Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRXOR_2" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                            <TextBox Canvas.Left="30" Canvas.Top="24" Width="20" Height="15" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8" TextAlignment="Center" Foreground="{ Binding ElementName=QRXORCircle_2, Path=Stroke}" Text="XOR"/>
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRXORCircle_2">
+                              <Path.Data>
+                                <EllipseGeometry Center="40,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <Path Stroke="Black" StrokeThickness="1" Data="M 40,40 v 50"/>
+                          </Canvas>
+                          <Canvas Grid.Row="2" Grid.Column="2">
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRShiftCircle_2" Fill="White">
+                              <Path.Data>
+                                <EllipseGeometry Center="60,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <TextBlock Width="20" Height="20"
                                      Canvas.Top="24" Canvas.Left="50"
                                      HorizontalAlignment="Center" VerticalAlignment="Center"
                                      FontSize="8"
                                      TextAlignment="Center" Foreground="{ Binding ElementName=QRShiftCircle_2, Path=Stroke}"
                                      Text="&lt;&lt;&lt;"
                           />
-                          <TextBlock FontSize="8" Canvas.Top="39" Canvas.Left="64" Text="12" Foreground="{ Binding ElementName=QRShiftCircle_2, Path=Stroke}"/>
-                          <Rectangle Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRShiftCell_2" Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRShift_2" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                        </Canvas>
-                      </Grid>
-                    </Canvas>
-                    <Canvas Grid.Column="5" Grid.RowSpan="4">
-                      <Rectangle Stroke="Black" Width="300" Height="260" StrokeThickness="1" />
-                      <Grid>
-                        <Grid.ColumnDefinitions>
-                          <ColumnDefinition Width="75"/>
-                          <!-- Width: 300/4 = 75 -->
-                          <ColumnDefinition Width="75"/>
-                          <ColumnDefinition Width="75"/>
-                          <ColumnDefinition Width="75"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                          <RowDefinition Height="10"/>
-                          <RowDefinition Height="60"/>
-                          <!-- Height: 260/4 = 65-->
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="10"/>
-                        </Grid.RowDefinitions>
-                        <Canvas Grid.Row="1" Grid.Column="0">
-                          <Rectangle Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRAddCell_3" Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRAdd_3" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRAddCircle_3" Fill="White">
-                            <Path.Data>
-                              <EllipseGeometry Center="21,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <Label Canvas.Top="11" Canvas.Left="10" Width="Auto" FontSize="18" Foreground="{ Binding ElementName=QRAddCircle_3, Path=Stroke}" Content="+"/>
-                          <Path Stroke="Black" StrokeThickness="1" Data="M 20,40 v 50"/>
-                        </Canvas>
-                        <Canvas Grid.Row="4" Grid.Column="1">
-                          <Rectangle Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRXORCell_3" Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRXOR_3" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                          <TextBox Canvas.Left="30" Canvas.Top="24" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8" TextAlignment="Center" Foreground="{ Binding ElementName=QRXORCircle_3, Path=Stroke}" Text="XOR"/>
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRXORCircle_3">
-                            <Path.Data>
-                              <EllipseGeometry Center="40,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                        </Canvas>
-                        <Canvas Grid.Row="1" Grid.Column="1">
-                          <Path Canvas.Left="30" Stroke="Black" StrokeThickness="1" Data="M 10,30 v 170"/>
-                        </Canvas>
-                        <Canvas Grid.Row="4" Grid.Column="2">
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRShiftCircle_3" Fill="White">
-                            <Path.Data>
-                              <EllipseGeometry Center="60,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <TextBlock Width="20" Height="20"
+                            <TextBlock FontSize="8" Canvas.Top="39" Canvas.Left="64" Text="12" Foreground="{ Binding ElementName=QRShiftCircle_2, Path=Stroke}"/>
+                            <Rectangle Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRShiftCell_2" Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRShift_2" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                          </Canvas>
+                        </Grid>
+                      </Canvas>
+                      <Canvas Grid.Column="5" Grid.RowSpan="4">
+                        <Rectangle Stroke="Black" Width="300" Height="260" StrokeThickness="1" />
+                        <Grid>
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="75"/>
+                            <!-- Width: 300/4 = 75 -->
+                            <ColumnDefinition Width="75"/>
+                            <ColumnDefinition Width="75"/>
+                            <ColumnDefinition Width="75"/>
+                          </Grid.ColumnDefinitions>
+                          <Grid.RowDefinitions>
+                            <RowDefinition Height="10"/>
+                            <RowDefinition Height="60"/>
+                            <!-- Height: 260/4 = 65-->
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="10"/>
+                          </Grid.RowDefinitions>
+                          <Canvas Grid.Row="1" Grid.Column="0">
+                            <Rectangle Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRAddCell_3" Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRAdd_3" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRAddCircle_3" Fill="White">
+                              <Path.Data>
+                                <EllipseGeometry Center="21,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <Label Canvas.Top="11" Canvas.Left="10" Width="Auto" FontSize="18" Foreground="{ Binding ElementName=QRAddCircle_3, Path=Stroke}" Content="+"/>
+                            <Path Stroke="Black" StrokeThickness="1" Data="M 20,40 v 50"/>
+                          </Canvas>
+                          <Canvas Grid.Row="4" Grid.Column="1">
+                            <Rectangle Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRXORCell_3" Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRXOR_3" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                            <TextBox Canvas.Left="30" Canvas.Top="24" Width="20" Height="20" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8" TextAlignment="Center" Foreground="{ Binding ElementName=QRXORCircle_3, Path=Stroke}" Text="XOR"/>
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRXORCircle_3">
+                              <Path.Data>
+                                <EllipseGeometry Center="40,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                          </Canvas>
+                          <Canvas Grid.Row="1" Grid.Column="1">
+                            <Path Canvas.Left="30" Stroke="Black" StrokeThickness="1" Data="M 10,30 v 170"/>
+                          </Canvas>
+                          <Canvas Grid.Row="4" Grid.Column="2">
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRShiftCircle_3" Fill="White">
+                              <Path.Data>
+                                <EllipseGeometry Center="60,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <TextBlock Width="20" Height="20"
                                      Canvas.Top="24" Canvas.Left="50"
                                      HorizontalAlignment="Center" VerticalAlignment="Center"
                                      FontSize="8"
                                      TextAlignment="Center" Foreground="{ Binding ElementName=QRShiftCircle_3, Path=Stroke}"
                                      Text="&lt;&lt;&lt;"
                           />
-                          <TextBlock FontSize="8" Canvas.Top="39" Canvas.Left="66" Text="8" Foreground="{ Binding ElementName=QRShiftCircle_3, Path=Stroke}"/>
-                          <Rectangle Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRShiftCell_3" Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRShift_3" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                        </Canvas>
-                      </Grid>
-                    </Canvas>
-                    <Canvas Grid.Column="7" Grid.RowSpan="4">
-                      <Rectangle Stroke="Black" Width="300" Height="260" StrokeThickness="1" />
-                      <Grid>
-                        <Grid.ColumnDefinitions>
-                          <ColumnDefinition Width="75"/>
-                          <!-- Width: 300/4 = 75 -->
-                          <ColumnDefinition Width="75"/>
-                          <ColumnDefinition Width="75"/>
-                          <ColumnDefinition Width="75"/>
-                        </Grid.ColumnDefinitions>
-                        <Grid.RowDefinitions>
-                          <RowDefinition Height="10"/>
-                          <RowDefinition Height="60"/>
-                          <!-- Height: 260/4 = 65-->
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="60"/>
-                          <RowDefinition Height="10"/>
-                        </Grid.RowDefinitions>
-                        <Canvas Grid.Row="3" Grid.Column="0">
-                          <Rectangle Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRAddCell_4" Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRAdd_4" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRAddCircle_4" Fill="White">
-                            <Path.Data>
-                              <EllipseGeometry Center="21,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <Label Canvas.Top="11" Canvas.Left="10" Width="Auto" FontSize="18" Foreground="{ Binding ElementName=QRAddCircle_4, Path=Stroke}" Content="+"/>
-                          <Path Stroke="Black" StrokeThickness="1" Data="M 20,40 v 50"/>
-                        </Canvas>
-                        <Canvas Grid.Row="2" Grid.Column="1">
-                          <Rectangle Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRXORCell_4" Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRXOR_4" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                          <TextBox Canvas.Left="30" Canvas.Top="24" Width="20" Height="10" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8" TextAlignment="Center" Foreground="{ Binding ElementName=QRXORCircle_4, Path=Stroke}" Text="XOR"/>
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRXORCircle_4">
-                            <Path.Data>
-                              <EllipseGeometry Center="40,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <Path Stroke="Black" StrokeThickness="1" Data="M 40,40 v 50"/>
-                        </Canvas>
-                        <Canvas Grid.Row="2" Grid.Column="2">
-                          <Path Stroke="Black" StrokeThickness="1" Name="QRShiftCircle_4" Fill="White">
-                            <Path.Data>
-                              <EllipseGeometry Center="60,30" RadiusX="10" RadiusY="10"/>
-                            </Path.Data>
-                          </Path>
-                          <TextBlock Width="20" Height="20"
+                            <TextBlock FontSize="8" Canvas.Top="39" Canvas.Left="66" Text="8" Foreground="{ Binding ElementName=QRShiftCircle_3, Path=Stroke}"/>
+                            <Rectangle Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRShiftCell_3" Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRShift_3" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                          </Canvas>
+                        </Grid>
+                      </Canvas>
+                      <Canvas Grid.Column="7" Grid.RowSpan="4">
+                        <Rectangle Stroke="Black" Width="300" Height="260" StrokeThickness="1" />
+                        <Grid>
+                          <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="75"/>
+                            <!-- Width: 300/4 = 75 -->
+                            <ColumnDefinition Width="75"/>
+                            <ColumnDefinition Width="75"/>
+                            <ColumnDefinition Width="75"/>
+                          </Grid.ColumnDefinitions>
+                          <Grid.RowDefinitions>
+                            <RowDefinition Height="10"/>
+                            <RowDefinition Height="60"/>
+                            <!-- Height: 260/4 = 65-->
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="60"/>
+                            <RowDefinition Height="10"/>
+                          </Grid.RowDefinitions>
+                          <Canvas Grid.Row="3" Grid.Column="0">
+                            <Rectangle Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRAddCell_4" Canvas.Top="10" Canvas.Left="40" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRAdd_4" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRAddCircle_4" Fill="White">
+                              <Path.Data>
+                                <EllipseGeometry Center="21,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <Label Canvas.Top="11" Canvas.Left="10" Width="Auto" FontSize="18" Foreground="{ Binding ElementName=QRAddCircle_4, Path=Stroke}" Content="+"/>
+                            <Path Stroke="Black" StrokeThickness="1" Data="M 20,40 v 50"/>
+                          </Canvas>
+                          <Canvas Grid.Row="2" Grid.Column="1">
+                            <Rectangle Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRXORCell_4" Canvas.Top="10" Canvas.Left="55" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRXOR_4" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                            <TextBox Canvas.Left="30" Canvas.Top="24" Width="20" Height="10" HorizontalAlignment="Center" VerticalAlignment="Center" FontSize="8" TextAlignment="Center" Foreground="{ Binding ElementName=QRXORCircle_4, Path=Stroke}" Text="XOR"/>
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRXORCircle_4">
+                              <Path.Data>
+                                <EllipseGeometry Center="40,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <Path Stroke="Black" StrokeThickness="1" Data="M 40,40 v 50"/>
+                          </Canvas>
+                          <Canvas Grid.Row="2" Grid.Column="2">
+                            <Path Stroke="Black" StrokeThickness="1" Name="QRShiftCircle_4" Fill="White">
+                              <Path.Data>
+                                <EllipseGeometry Center="60,30" RadiusX="10" RadiusY="10"/>
+                              </Path.Data>
+                            </Path>
+                            <TextBlock Width="20" Height="20"
                                      Canvas.Top="24" Canvas.Left="50"
                                      HorizontalAlignment="Center" VerticalAlignment="Center"
                                      FontSize="8"
                                      TextAlignment="Center" Foreground="{ Binding ElementName=QRShiftCircle_4, Path=Stroke}"
                                      Text="&lt;&lt;&lt;"
                           />
-                          <TextBlock FontSize="8" Canvas.Top="39" Canvas.Left="66" Text="7" Foreground="{ Binding ElementName=QRShiftCircle_4, Path=Stroke}"/>
-                          <Rectangle Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" Fill="White"/>
-                          <Border Name="QRShiftCell_4" Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
-                            <TextBox Style="{StaticResource hexTextBox}" Name="QRShift_4" VerticalAlignment="Center" HorizontalAlignment="Center" />
-                          </Border>
-                        </Canvas>
-                      </Grid>
-                    </Canvas>
-                  </Grid>
+                            <TextBlock FontSize="8" Canvas.Top="39" Canvas.Left="66" Text="7" Foreground="{ Binding ElementName=QRShiftCircle_4, Path=Stroke}"/>
+                            <Rectangle Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" Fill="White"/>
+                            <Border Name="QRShiftCell_4" Canvas.Top="10" Canvas.Left="75" Width="65" Height="40" BorderBrush="Black" BorderThickness="1">
+                              <TextBox Style="{StaticResource hexTextBox}" Name="QRShift_4" VerticalAlignment="Center" HorizontalAlignment="Center" />
+                            </Border>
+                          </Canvas>
+                        </Grid>
+                      </Canvas>
+                    </Grid>
+                  </Canvas>
                 </Canvas>
-              </Canvas>
-            </Viewbox>
+              </Viewbox>
+            </Grid>
           </Grid>
         </Grid>
       </Grid>

--- a/ChaCha/Visualization/ChaChaPresentation.xaml
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml
@@ -53,14 +53,14 @@
           <RowDefinition Height="8*"/>
         </Grid.RowDefinitions>
         <Grid Grid.Row="1">
-          <Grid.ColumnDefinitions>
-            <ColumnDefinition Width="1*"/>
-            <ColumnDefinition Width="4*"/>
-          </Grid.ColumnDefinitions>
-          <StackPanel Margin="1" Name="PageNavBar" Grid.Column="0" Orientation="Horizontal" HorizontalAlignment="Left">
+          <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+          </Grid.RowDefinitions>
+          <StackPanel Margin="1" Name="PageNavBar" Grid.Row="0" Orientation="Horizontal" HorizontalAlignment="Left">
             <!-- Page click handlers are inserted here in code-behind -->
           </StackPanel>
-          <StackPanel Margin="1" Name="ActionNavBar" Grid.Column="1" Orientation="Horizontal" HorizontalAlignment="Right">
+          <StackPanel Margin="1" Name="ActionNavBar" Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Left">
             <!-- Action click handlers are inserted here in code-behind -->
           </StackPanel>
         </Grid>

--- a/ChaCha/Visualization/ChaChaPresentation.xaml
+++ b/ChaCha/Visualization/ChaChaPresentation.xaml
@@ -143,7 +143,7 @@
       </Grid>
     </ContentControl>
     <!-- ChaCha State matrix page -->
-    <ContentControl Name="UIStateMatrixPage" Visibility="Collapsed" Template="{ StaticResource PageTemplate }">
+    <ContentControl Name="UIStateMatrixPage" Visibility="Visible" Template="{ StaticResource PageTemplate }">
       <Grid>
         <Grid.Resources>
           <Style TargetType="TextBox">
@@ -159,8 +159,7 @@
         <Grid Grid.Row="1">
           <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1.34*"/>
-            <ColumnDefinition/>
-            <ColumnDefinition/>
+            <ColumnDefinition Width="2*"/>
           </Grid.ColumnDefinitions>
           <Grid Grid.Column="0">
             <Grid>
@@ -316,7 +315,7 @@
               </Grid>
             </Grid>
           </Grid>
-          <Grid Margin="100,0,0,0" Grid.Column="1" Grid.ColumnSpan="2">
+          <Grid Margin="100,0,0,0" Grid.Column="1">
             <Grid.RowDefinitions>
               <RowDefinition Height="14*"></RowDefinition>
               <RowDefinition Height="2*"></RowDefinition>

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -161,34 +161,75 @@ namespace Cryptool.Plugins.ChaCha
             pageNavBar.Children.Add(keystream);
         }
 
-        private void InitKeystreamNavigation(Page p)
+        private void InitKeystreamNavigation(Page p, int totalKeystreamBlocks, int totalRounds)
         {
             // Assume that general page navigation bar has already been initialized
             StackPanel pageNavBar = p.PageNavigationBar;
 
+            Grid keystreamBlockGrid = new Grid() { Margin = new Thickness(0, -15, 0, 0) };
+            keystreamBlockGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(18.75) });
+            keystreamBlockGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(18.75) });
+            TextBlock keystreamLabel = new TextBlock() { Text = "Keystream Block", HorizontalAlignment = HorizontalAlignment.Center };
+            StackPanel keystreamBlockBottomRow = new StackPanel() { Orientation = Orientation.Horizontal };
+            Grid.SetRow(keystreamLabel, 0);
+            Grid.SetRow(keystreamBlockBottomRow, 1);
             Button previousKeystreamBlock = CreatePrevNavigationButton();
             TextBox currentKeystreamBlock = CreateNavigationTextBox();
+            TextBlock keystreamDelimiter = new TextBlock() { Text = "/" };
+            TextBlock totalKeystreamBlockLabel = new TextBlock() { Text = totalKeystreamBlocks.ToString() };
             Button nextKeystreamBlock = CreateNextNavigationButton();
+            keystreamBlockBottomRow.Children.Add(previousKeystreamBlock);
+            keystreamBlockBottomRow.Children.Add(currentKeystreamBlock);
+            keystreamBlockBottomRow.Children.Add(keystreamDelimiter);
+            keystreamBlockBottomRow.Children.Add(totalKeystreamBlockLabel);
+            keystreamBlockBottomRow.Children.Add(nextKeystreamBlock);
+            keystreamBlockGrid.Children.Add(keystreamLabel);
+            keystreamBlockGrid.Children.Add(keystreamBlockBottomRow);
+            pageNavBar.Children.Add(keystreamBlockGrid);
 
+
+            Grid roundGrid = new Grid() { Margin = new Thickness(0, -15, 0, 0) };
+            roundGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(18.75) });
+            roundGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(18.75) });
+            TextBlock roundLabel = new TextBlock() { Text = "Round", HorizontalAlignment = HorizontalAlignment.Center };
+            StackPanel roundBottomRow = new StackPanel() { Orientation = Orientation.Horizontal };
+            Grid.SetRow(roundLabel, 0);
+            Grid.SetRow(roundBottomRow, 1);
             Button previousRound = CreatePrevNavigationButton();
             TextBox currentRound = CreateNavigationTextBox();
+            TextBlock delimiterRound = new TextBlock() { Text = "/" };
+            TextBlock totalRoundsLabel = new TextBlock() { Text = totalRounds.ToString() };
             Button nextRound = CreateNextNavigationButton();
+            roundBottomRow.Children.Add(previousRound);
+            roundBottomRow.Children.Add(currentRound);
+            roundBottomRow.Children.Add(delimiterRound);
+            roundBottomRow.Children.Add(totalRoundsLabel);
+            roundBottomRow.Children.Add(nextRound);
+            roundGrid.Children.Add(roundLabel);
+            roundGrid.Children.Add(roundBottomRow);
+            pageNavBar.Children.Add(roundGrid);
 
+
+            Grid quarterroundGrid = new Grid() { Margin = new Thickness(0, -15, 0, 0) };
+            quarterroundGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(18.75) });
+            quarterroundGrid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(18.75) });
+            TextBlock quarterroundLabel = new TextBlock() { Text = "Quarterround", HorizontalAlignment = HorizontalAlignment.Center };
+            StackPanel quarterroundBottomRow = new StackPanel() { Orientation = Orientation.Horizontal };
+            Grid.SetRow(quarterroundLabel, 0);
+            Grid.SetRow(quarterroundBottomRow, 1);
             Button previousQuarterround = CreatePrevNavigationButton();
             TextBox currentQuarterround = CreateNavigationTextBox();
+            TextBlock delimiterQuarterround = new TextBlock() { Text = "/" };
+            TextBlock totalQuarterRoundsLabel = new TextBlock() { Text = "4" };
             Button nextQuarterround = CreateNextNavigationButton();
-
-            pageNavBar.Children.Add(previousKeystreamBlock);
-            pageNavBar.Children.Add(currentKeystreamBlock);
-            pageNavBar.Children.Add(nextKeystreamBlock);
-
-            pageNavBar.Children.Add(previousRound);
-            pageNavBar.Children.Add(currentRound);
-            pageNavBar.Children.Add(nextRound);
-
-            pageNavBar.Children.Add(previousQuarterround);
-            pageNavBar.Children.Add(currentQuarterround);
-            pageNavBar.Children.Add(nextQuarterround);
+            quarterroundBottomRow.Children.Add(previousQuarterround);
+            quarterroundBottomRow.Children.Add(currentQuarterround);
+            quarterroundBottomRow.Children.Add(delimiterQuarterround);
+            quarterroundBottomRow.Children.Add(totalQuarterRoundsLabel);
+            quarterroundBottomRow.Children.Add(nextQuarterround);
+            quarterroundGrid.Children.Add(quarterroundLabel);
+            quarterroundGrid.Children.Add(quarterroundBottomRow);
+            pageNavBar.Children.Add(quarterroundGrid);
         }
 
         private void InitActionSliderNavigationBar(StackPanel actionNavBar, int totalActions)
@@ -284,7 +325,7 @@ namespace Cryptool.Plugins.ChaCha
             {
                 Page p = _pages[i];
                 InitPageNavigationBar(p);
-                if (i >= 3) InitKeystreamNavigation(p);
+                if (i >= 3) InitKeystreamNavigation(p, KeystreamBlocksNeeded, Rounds);
             }
             InitActionNavigationBar(CurrentPage);
         }

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -239,10 +239,14 @@ namespace Cryptool.Plugins.ChaCha
             Grid.SetRow(keystreamLabel, 0);
             Grid.SetRow(keystreamBlockBottomRow, 1);
             Button previousKeystreamBlock = CreatePrevNavigationButton();
+            previousKeystreamBlock.Click += PrevKeystreamBlock_Click;
+            previousKeystreamBlock.SetBinding(Button.IsEnabledProperty, new Binding("PrevKeystreamBlockIsEnabled"));
             TextBox currentKeystreamBlock = CreateKeystreamBlockTextBox(totalKeystreamBlocks);
             TextBlock keystreamDelimiter = new TextBlock() { Text = "/" };
             TextBlock totalKeystreamBlockLabel = new TextBlock() { Text = totalKeystreamBlocks.ToString() };
             Button nextKeystreamBlock = CreateNextNavigationButton();
+            nextKeystreamBlock.Click += NextKeystreamBlock_Click;
+            nextKeystreamBlock.SetBinding(Button.IsEnabledProperty, new Binding("NextKeystreamBlockIsEnabled"));
             keystreamBlockBottomRow.Children.Add(previousKeystreamBlock);
             keystreamBlockBottomRow.Children.Add(currentKeystreamBlock);
             keystreamBlockBottomRow.Children.Add(keystreamDelimiter);
@@ -365,6 +369,11 @@ namespace Cryptool.Plugins.ChaCha
                     NextPage_Click(null, null);
                 }
             }
+        }
+
+        private void MoveToKeystreamPage(int n)
+        {
+            MoveToPage(2 + n);
         }
 
         private void MoveToPage(int n)
@@ -530,6 +539,8 @@ namespace Cryptool.Plugins.ChaCha
             {
                 _currentKeystreamBlockTextBox = value;
                 OnPropertyChanged("CurrentKeystreamBlockTextBox");
+                OnPropertyChanged("PrevKeystreamBlockIsEnabled");
+                OnPropertyChanged("NextKeystreamBlockIsEnabled");
             }
         }
 
@@ -588,6 +599,10 @@ namespace Cryptool.Plugins.ChaCha
         public bool NextRoundIsEnabled => CurrentRoundIndex != 20;
 
         public bool PrevRoundIsEnabled => CurrentRoundIndex >= 1;
+
+        public bool NextKeystreamBlockIsEnabled => CurrentKeystreamBlockTextBox != KeystreamBlocksNeeded;
+
+        public bool PrevKeystreamBlockIsEnabled => CurrentKeystreamBlockTextBox > 1;
 
         private int _currentRoundIndex = 0;
         public int CurrentRoundIndex
@@ -822,6 +837,18 @@ namespace Cryptool.Plugins.ChaCha
             int endIndex = GetLabeledPageActionIndex(KeystreamBlockGenPage.RoundStartLabel(CurrentRoundIndex + 1), CurrentActions) + 1;
             Debug.Assert(startIndex < endIndex, $"startIndex ({startIndex}) should be lower than endIndex ({endIndex}) when clicking on next round");
             MoveToActionAsync(endIndex);
+        }
+
+        private void NextKeystreamBlock_Click(object sender, RoutedEventArgs e)
+        {
+            int pageIndex = CurrentKeystreamBlockTextBox + 1;
+            MoveToKeystreamPage(pageIndex);
+        }
+
+        private void PrevKeystreamBlock_Click(object sender, RoutedEventArgs e)
+        {
+            int pageIndex = CurrentKeystreamBlockTextBox - 1;
+            MoveToKeystreamPage(pageIndex);
         }
 
         private void QR_Click(int qrLabelIndex)

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -160,6 +160,7 @@ namespace Cryptool.Plugins.ChaCha
             Button overview = CreatePageButton("Overview", pageIndex, 1, 64);
             Button stateMatrixInit = CreatePageButton("State Matrix Initialization", pageIndex, 2, 160);
             Button keystream = CreatePageButton("Keystream Generation", pageIndex, 3, 160);
+            if (pageIndex >= 3) keystream.FontWeight = FontWeights.Bold;
             pageNavBar.Children.Add(start);
             pageNavBar.Children.Add(overview);
             pageNavBar.Children.Add(stateMatrixInit);

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -226,6 +226,35 @@ namespace Cryptool.Plugins.ChaCha
             return current;
         }
 
+        private TextBox CreateQuarterroundTextBox()
+        {
+            TextBox current = CreateNavigationTextBox();
+            Binding actionIndexBinding = new Binding("CurrentQuarterroundIndexTextBox")
+            { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged };
+            ValidationRule inputActionIndexRule = new InputActionIndexRule(1, 4);
+            actionIndexBinding.ValidationRules.Add(inputActionIndexRule);
+            current.SetBinding(TextBox.TextProperty, actionIndexBinding);
+
+            void HandleKeyDown(object sender, KeyEventArgs e)
+            {
+                if (e.Key == Key.Return)
+                {
+                    string rawValue = ((TextBox)sender).Text;
+                    ValidationResult result = inputActionIndexRule.Validate(rawValue, null);
+                    if (result == ValidationResult.ValidResult)
+                    {
+                        int value = int.Parse(rawValue);
+                        string searchLabel = KeystreamBlockGenPage.QuarterroundStartLabelWithRound(value, CurrentRoundIndex);
+                        int qrActionIndex = GetLabeledPageActionIndex(searchLabel, CurrentActions) + 1;
+                        MoveToActionAsync(qrActionIndex);
+                    }
+                }
+            }
+
+            current.KeyDown += HandleKeyDown;
+            return current;
+        }
+
         private void InitKeystreamNavigation(Page p, int totalKeystreamBlocks, int totalRounds)
         {
             // Assume that general page navigation bar has already been initialized
@@ -291,7 +320,7 @@ namespace Cryptool.Plugins.ChaCha
             Grid.SetRow(quarterroundLabel, 0);
             Grid.SetRow(quarterroundBottomRow, 1);
             Button previousQuarterround = CreatePrevNavigationButton();
-            TextBox currentQuarterround = CreateNavigationTextBox();
+            TextBox currentQuarterround = CreateQuarterroundTextBox();
             TextBlock delimiterQuarterround = new TextBlock() { Text = "/" };
             TextBlock totalQuarterRoundsLabel = new TextBlock() { Text = "4" };
             Button nextQuarterround = CreateNextNavigationButton();
@@ -478,6 +507,7 @@ namespace Cryptool.Plugins.ChaCha
         private int _currentActionIndexTextBox = 0;
         private int _currentKeystreamBlockTextBox = 1;
         private int _currentRoundIndexTextBox = 1;
+        private int _currentQuarterroundIndexTextBox = 1;
 
         private bool _executionFinished = false;
         private bool _inputValid = false;
@@ -551,6 +581,16 @@ namespace Cryptool.Plugins.ChaCha
             {
                 _currentRoundIndexTextBox = value;
                 OnPropertyChanged("CurrentRoundIndexTextBox");
+            }
+        }
+
+        public int CurrentQuarterroundIndexTextBox
+        {
+            get => _currentQuarterroundIndexTextBox;
+            set
+            {
+                _currentQuarterroundIndexTextBox = value;
+                OnPropertyChanged("CurrentQuarterroundIndexTextBox");
             }
         }
 

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -171,7 +171,7 @@ namespace Cryptool.Plugins.ChaCha
         private TextBox CreateKeystreamBlockTextBox(int totalKeystreamBlocks)
         {
             TextBox current = CreateNavigationTextBox();
-            Binding actionIndexBinding = new Binding("CurrentKeystreamBlock")
+            Binding actionIndexBinding = new Binding("CurrentKeystreamBlockTextBox")
             { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged };
             ValidationRule inputActionIndexRule = new InputActionIndexRule(1, totalKeystreamBlocks);
             actionIndexBinding.ValidationRules.Add(inputActionIndexRule);
@@ -200,7 +200,7 @@ namespace Cryptool.Plugins.ChaCha
         private TextBox CreateRoundTextBox(int totalRounds)
         {
             TextBox current = CreateNavigationTextBox();
-            Binding actionIndexBinding = new Binding("CurrentRoundIndex")
+            Binding actionIndexBinding = new Binding("CurrentRoundIndexTextBox")
             { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged };
             ValidationRule inputActionIndexRule = new InputActionIndexRule(1, totalRounds);
             actionIndexBinding.ValidationRules.Add(inputActionIndexRule);
@@ -216,6 +216,7 @@ namespace Cryptool.Plugins.ChaCha
                     {
                         int value = int.Parse(rawValue);
                         int destination = GetLabeledPageActionIndex(KeystreamBlockGenPage.RoundStartLabel(value), CurrentActions) + 1;
+                        CurrentRoundIndex = value;
                         MoveToActionAsync(destination);
                     }
                 }
@@ -462,8 +463,8 @@ namespace Cryptool.Plugins.ChaCha
         // action index value for TextBox.
         // Prevents direct write-access to actual current action index value while still being able to read from it.
         private int _currentActionIndexTextBox = 0;
-
-        private int _currentKeystreamBlock = 1;
+        private int _currentKeystreamBlockTextBox = 1;
+        private int _currentRoundIndexTextBox = 1;
 
         private bool _executionFinished = false;
         private bool _inputValid = false;
@@ -478,7 +479,7 @@ namespace Cryptool.Plugins.ChaCha
                 CurrentActionIndex = 0;
                 if(_currentPageIndex >= 3)
                 {
-                    CurrentKeystreamBlock = _currentPageIndex - 2;
+                    CurrentKeystreamBlockTextBox = _currentPageIndex - 2;
                 }
                 OnPropertyChanged("CurrentPageIndex");
                 OnPropertyChanged("CurrentPage");
@@ -518,13 +519,23 @@ namespace Cryptool.Plugins.ChaCha
             }
         }
 
-        public int CurrentKeystreamBlock
+        public int CurrentKeystreamBlockTextBox
         {
-            get => _currentKeystreamBlock;
+            get => _currentKeystreamBlockTextBox;
             set
             {
-                _currentKeystreamBlock = value;
-                OnPropertyChanged("CurrentKeystreamBlock");
+                _currentKeystreamBlockTextBox = value;
+                OnPropertyChanged("CurrentKeystreamBlockTextBox");
+            }
+        }
+
+        public int CurrentRoundIndexTextBox
+        {
+            get => _currentRoundIndexTextBox;
+            set
+            {
+                _currentRoundIndexTextBox = value;
+                OnPropertyChanged("CurrentRoundIndexTextBox");
             }
         }
 
@@ -584,6 +595,7 @@ namespace Cryptool.Plugins.ChaCha
             set
             {
                 _currentRoundIndex = value;
+                CurrentRoundIndexTextBox = value;
                 OnPropertyChanged("CurrentRoundIndex");
                 OnPropertyChanged("NextRoundIsEnabled");
                 OnPropertyChanged("PrevRoundIsEnabled");

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -197,6 +197,34 @@ namespace Cryptool.Plugins.ChaCha
         }
 
 
+        private TextBox CreateRoundTextBox(int totalRounds)
+        {
+            TextBox current = CreateNavigationTextBox();
+            Binding actionIndexBinding = new Binding("CurrentRoundIndex")
+            { Mode = BindingMode.TwoWay, UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged };
+            ValidationRule inputActionIndexRule = new InputActionIndexRule(1, totalRounds);
+            actionIndexBinding.ValidationRules.Add(inputActionIndexRule);
+            current.SetBinding(TextBox.TextProperty, actionIndexBinding);
+
+            void HandleKeyDown(object sender, KeyEventArgs e)
+            {
+                if (e.Key == Key.Return)
+                {
+                    string rawValue = ((TextBox)sender).Text;
+                    ValidationResult result = inputActionIndexRule.Validate(rawValue, null);
+                    if (result == ValidationResult.ValidResult)
+                    {
+                        int value = int.Parse(rawValue);
+                        int destination = GetLabeledPageActionIndex(KeystreamBlockGenPage.RoundStartLabel(value), CurrentActions) + 1;
+                        MoveToActionAsync(destination);
+                    }
+                }
+            }
+
+            current.KeyDown += HandleKeyDown;
+            return current;
+        }
+
         private void InitKeystreamNavigation(Page p, int totalKeystreamBlocks, int totalRounds)
         {
             // Assume that general page navigation bar has already been initialized
@@ -232,7 +260,7 @@ namespace Cryptool.Plugins.ChaCha
             Grid.SetRow(roundLabel, 0);
             Grid.SetRow(roundBottomRow, 1);
             Button previousRound = CreatePrevNavigationButton();
-            TextBox currentRound = CreateNavigationTextBox();
+            TextBox currentRound = CreateRoundTextBox(totalRounds);
             TextBlock delimiterRound = new TextBlock() { Text = "/" };
             TextBlock totalRoundsLabel = new TextBlock() { Text = totalRounds.ToString() };
             Button nextRound = CreateNextNavigationButton();

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -137,7 +137,6 @@ namespace Cryptool.Plugins.ChaCha
             return current;
         }
 
-        private List<Button> _pageButtons = new List<Button>();
         private Button CreatePageButton(string text, int currentPageIndex, int toPageIndex, int width)
         {
             Button b = new Button()
@@ -149,7 +148,6 @@ namespace Cryptool.Plugins.ChaCha
             // since each page has its own dedicated navigation bar, the button for the current page is always bold
             if (currentPageIndex == toPageIndex) b.FontWeight = FontWeights.Bold;
             b.Click += new RoutedEventHandler(MoveToPageClickWrapper(toPageIndex));
-            _pageButtons.Add(b);
             return b;
         }
 
@@ -158,7 +156,6 @@ namespace Cryptool.Plugins.ChaCha
             int pageIndex = _pages.FindIndex(p_ => p_ == p);
             StackPanel pageNavBar = p.PageNavigationBar;
             pageNavBar.Children.Clear();
-            _pageButtons.Clear();
             Button start = CreatePageButton("Start", pageIndex, 0, 32);
             Button overview = CreatePageButton("Overview", pageIndex, 1, 64);
             Button stateMatrixInit = CreatePageButton("State Matrix Initialization", pageIndex, 2, 160);

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -185,9 +185,7 @@ namespace Cryptool.Plugins.ChaCha
                     ValidationResult result = inputActionIndexRule.Validate(value, null);
                     if (result == ValidationResult.ValidResult)
                     {
-                        // +2 because keystream pages start at index 3, so if we get the value 1
-                        // we want to go to page index 3 etc.
-                        MoveToPage(2 + int.Parse(value));
+                        MoveToKeystreamPage(int.Parse(value));
                     }
                 }
             }
@@ -214,10 +212,7 @@ namespace Cryptool.Plugins.ChaCha
                     ValidationResult result = inputActionIndexRule.Validate(rawValue, null);
                     if (result == ValidationResult.ValidResult)
                     {
-                        int value = int.Parse(rawValue);
-                        int destination = GetLabeledPageActionIndex(KeystreamBlockGenPage.RoundStartLabel(value), CurrentActions) + 1;
-                        CurrentRoundIndex = value;
-                        MoveToActionAsync(destination);
+                        MoveToRound(int.Parse(rawValue));
                     }
                 }
             }
@@ -243,10 +238,7 @@ namespace Cryptool.Plugins.ChaCha
                     ValidationResult result = inputActionIndexRule.Validate(rawValue, null);
                     if (result == ValidationResult.ValidResult)
                     {
-                        int value = int.Parse(rawValue);
-                        string searchLabel = KeystreamBlockGenPage.QuarterroundStartLabelWithRound(value, CurrentRoundIndex);
-                        int qrActionIndex = GetLabeledPageActionIndex(searchLabel, CurrentActions) + 1;
-                        MoveToActionAsync(qrActionIndex);
+                        MoveToQuarterround(int.Parse(rawValue));
                     }
                 }
             }
@@ -746,6 +738,22 @@ namespace Cryptool.Plugins.ChaCha
             {
                 return CurrentPage.Cache;
             }
+        }
+
+
+        private void MoveToQuarterround(int n)
+        {
+            string searchLabel = KeystreamBlockGenPage.QuarterroundStartLabelWithRound(n, CurrentRoundIndex);
+            int qrActionIndex = GetLabeledPageActionIndex(searchLabel, CurrentActions) + 1;
+            CurrentQuarterroundIndexTextBox = n;
+            MoveToActionAsync(qrActionIndex);
+        }
+
+        private void MoveToRound(int n)
+        {
+            int destination = GetLabeledPageActionIndex(KeystreamBlockGenPage.RoundStartLabel(n), CurrentActions) + 1;
+            CurrentRoundIndex = n;
+            MoveToActionAsync(destination);
         }
 
         /**

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -196,7 +196,6 @@ namespace Cryptool.Plugins.ChaCha
             return current;
         }
 
-        public int CurrentKeystreamBlock { get; set; } = 1;
 
         private void InitKeystreamNavigation(Page p, int totalKeystreamBlocks, int totalRounds)
         {
@@ -436,6 +435,8 @@ namespace Cryptool.Plugins.ChaCha
         // Prevents direct write-access to actual current action index value while still being able to read from it.
         private int _currentActionIndexTextBox = 0;
 
+        private int _currentKeystreamBlock = 1;
+
         private bool _executionFinished = false;
         private bool _inputValid = false;
 
@@ -447,12 +448,17 @@ namespace Cryptool.Plugins.ChaCha
                 if (value == _currentPageIndex) return;
                 _currentPageIndex = value;
                 CurrentActionIndex = 0;
+                if(_currentPageIndex >= 3)
+                {
+                    CurrentKeystreamBlock = _currentPageIndex - 2;
+                }
                 OnPropertyChanged("CurrentPageIndex");
                 OnPropertyChanged("CurrentPage");
                 OnPropertyChanged("NextPageIsEnabled");
                 OnPropertyChanged("PrevPageIsEnabled");
                 OnPropertyChanged("NextRoundIsEnabled");
                 OnPropertyChanged("PrevRoundIsEnabled");
+                OnPropertyChanged("CurrentKeystreamBlock");
                 InitActionNavigationBar(CurrentPage);
             }
         }
@@ -481,6 +487,16 @@ namespace Cryptool.Plugins.ChaCha
                 _currentActionIndexTextBox = value;
                 OnPropertyChanged("CurrentActionIndexTextBox");
 
+            }
+        }
+
+        public int CurrentKeystreamBlock
+        {
+            get => _currentKeystreamBlock;
+            set
+            {
+                _currentKeystreamBlock = value;
+                OnPropertyChanged("CurrentKeystreamBlock");
             }
         }
 

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -11,6 +11,7 @@ using System.Windows.Controls;
 using System.Windows.Controls.Primitives;
 using System.Windows.Data;
 using System.Windows.Input;
+using System.Windows.Navigation;
 using System.Windows.Threading;
 
 namespace Cryptool.Plugins.ChaCha
@@ -312,10 +313,14 @@ namespace Cryptool.Plugins.ChaCha
             Grid.SetRow(quarterroundLabel, 0);
             Grid.SetRow(quarterroundBottomRow, 1);
             Button previousQuarterround = CreatePrevNavigationButton();
+            previousQuarterround.Click += PrevQuarterround_Click;
+            previousQuarterround.SetBinding(Button.IsEnabledProperty, new Binding("PrevQuarterroundIsEnabled"));
             TextBox currentQuarterround = CreateQuarterroundTextBox();
             TextBlock delimiterQuarterround = new TextBlock() { Text = "/" };
             TextBlock totalQuarterRoundsLabel = new TextBlock() { Text = "4" };
             Button nextQuarterround = CreateNextNavigationButton();
+            nextQuarterround.Click += NextQuarterround_Click;
+            nextQuarterround.SetBinding(Button.IsEnabledProperty, new Binding("NextQuarterroundIsEnabled"));
             quarterroundBottomRow.Children.Add(previousQuarterround);
             quarterroundBottomRow.Children.Add(currentQuarterround);
             quarterroundBottomRow.Children.Add(delimiterQuarterround);
@@ -583,6 +588,8 @@ namespace Cryptool.Plugins.ChaCha
             {
                 _currentQuarterroundIndexTextBox = value;
                 OnPropertyChanged("CurrentQuarterroundIndexTextBox");
+                OnPropertyChanged("NextQuarterroundIsEnabled");
+                OnPropertyChanged("PrevQuarterroundIsEnabled");
             }
         }
 
@@ -635,6 +642,11 @@ namespace Cryptool.Plugins.ChaCha
         public bool NextKeystreamBlockIsEnabled => CurrentKeystreamBlockTextBox != KeystreamBlocksNeeded;
 
         public bool PrevKeystreamBlockIsEnabled => CurrentKeystreamBlockTextBox > 1;
+
+        public bool NextQuarterroundIsEnabled => CurrentQuarterroundIndexTextBox != 4;
+
+        public bool PrevQuarterroundIsEnabled => CurrentQuarterroundIndexTextBox > 1;
+
 
         private int _currentRoundIndex = 0;
         public int CurrentRoundIndex
@@ -897,6 +909,18 @@ namespace Cryptool.Plugins.ChaCha
         {
             int pageIndex = CurrentKeystreamBlockTextBox - 1;
             MoveToKeystreamPage(pageIndex);
+        }
+
+        private void PrevQuarterround_Click(object sender, RoutedEventArgs e)
+        {
+            int qrIndex = CurrentQuarterroundIndexTextBox - 1;
+            MoveToQuarterround(qrIndex);
+        }
+
+        private void NextQuarterround_Click(object sender, RoutedEventArgs e)
+        {
+            int qrIndex = CurrentQuarterroundIndexTextBox + 1;
+            MoveToQuarterround(qrIndex);
         }
 
         private void QR_Click(int qrLabelIndex)

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -25,6 +25,26 @@ namespace Cryptool.Plugins.ChaCha
             return b;
         }
 
+        private static Button CreatePrevNavigationButton()
+        {
+            Button b = CreateNavigationButton();
+            b.Content = "<";
+            return b;
+        }
+
+        private static Button CreateNextNavigationButton()
+        {
+            Button b = CreateNavigationButton();
+            b.Content = ">";
+            return b;
+        }
+
+        private static TextBox CreateNavigationTextBox()
+        {
+            TextBox tb = new TextBox { Height = 18.75, Width = 24, Margin = new Thickness(1, 0, 1, 0) };
+            return tb;
+        }
+
         private Slider CreateActionNavigationSlider(int totalActions)
         {
             Slider s = new Slider
@@ -134,9 +154,41 @@ namespace Cryptool.Plugins.ChaCha
             Button start = CreatePageButton("Start", pageIndex, 0, 32);
             Button overview = CreatePageButton("Overview", pageIndex, 1, 64);
             Button stateMatrixInit = CreatePageButton("State Matrix Initialization", pageIndex, 2, 160);
+            Button keystream = CreatePageButton("Keystream Generation", pageIndex, 3, 160);
             pageNavBar.Children.Add(start);
             pageNavBar.Children.Add(overview);
             pageNavBar.Children.Add(stateMatrixInit);
+            pageNavBar.Children.Add(keystream);
+        }
+
+        private void InitKeystreamNavigation(Page p)
+        {
+            // Assume that general page navigation bar has already been initialized
+            StackPanel pageNavBar = p.PageNavigationBar;
+
+            Button previousKeystreamBlock = CreatePrevNavigationButton();
+            TextBox currentKeystreamBlock = CreateNavigationTextBox();
+            Button nextKeystreamBlock = CreateNextNavigationButton();
+
+            Button previousRound = CreatePrevNavigationButton();
+            TextBox currentRound = CreateNavigationTextBox();
+            Button nextRound = CreateNextNavigationButton();
+
+            Button previousQuarterround = CreatePrevNavigationButton();
+            TextBox currentQuarterround = CreateNavigationTextBox();
+            Button nextQuarterround = CreateNextNavigationButton();
+
+            pageNavBar.Children.Add(previousKeystreamBlock);
+            pageNavBar.Children.Add(currentKeystreamBlock);
+            pageNavBar.Children.Add(nextKeystreamBlock);
+
+            pageNavBar.Children.Add(previousRound);
+            pageNavBar.Children.Add(currentRound);
+            pageNavBar.Children.Add(nextRound);
+
+            pageNavBar.Children.Add(previousQuarterround);
+            pageNavBar.Children.Add(currentQuarterround);
+            pageNavBar.Children.Add(nextQuarterround);
         }
 
         private void InitActionSliderNavigationBar(StackPanel actionNavBar, int totalActions)
@@ -226,10 +278,13 @@ namespace Cryptool.Plugins.ChaCha
             AddPage(Page.LandingPage(this));
             AddPage(Page.WorkflowPage(this));
             AddPage(Page.StateMatrixPage(this));
+            AddPage(Page.KeystreamBlockGenPage(this, 1));
             CollapseAllPagesExpect(START_VISUALIZATION_ON_PAGE_INDEX);
-            foreach(Page p in _pages)
+            for (int i = 0; i < _pages.Count; ++i)
             {
+                Page p = _pages[i];
                 InitPageNavigationBar(p);
+                if (i >= 3) InitKeystreamNavigation(p);
             }
             InitActionNavigationBar(CurrentPage);
         }

--- a/ChaCha/Visualization/Navigation/Navigation.cs
+++ b/ChaCha/Visualization/Navigation/Navigation.cs
@@ -261,10 +261,14 @@ namespace Cryptool.Plugins.ChaCha
             Grid.SetRow(roundLabel, 0);
             Grid.SetRow(roundBottomRow, 1);
             Button previousRound = CreatePrevNavigationButton();
+            previousRound.Click += PrevRound_Click;
+            previousRound.SetBinding(Button.IsEnabledProperty, new Binding("PrevRoundIsEnabled"));
             TextBox currentRound = CreateRoundTextBox(totalRounds);
             TextBlock delimiterRound = new TextBlock() { Text = "/" };
             TextBlock totalRoundsLabel = new TextBlock() { Text = totalRounds.ToString() };
             Button nextRound = CreateNextNavigationButton();
+            nextRound.Click += NextRound_Click;
+            nextRound.SetBinding(Button.IsEnabledProperty, new Binding("NextRoundIsEnabled"));
             roundBottomRow.Children.Add(previousRound);
             roundBottomRow.Children.Add(currentRound);
             roundBottomRow.Children.Add(delimiterRound);

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -218,6 +218,7 @@ namespace Cryptool.Plugins.ChaCha
                     // update round indicator
                     int round = CalculateRoundFromQRIndex(qrIndex);
                     pres.CurrentRoundIndex = round;
+                    pres.CurrentQuarterroundIndexTextBox = (qrIndex - 1) % 4 + 1;
                     pres.Nav.Replace(pres.CurrentRound, round.ToString());
                     HideAllQRArrowsExcept(pres, ((qrIndex - 1) % 8) + 1);
 
@@ -802,11 +803,13 @@ namespace Cryptool.Plugins.ChaCha
             }
             PageAction updateQRArrow = new PageAction(() =>
             {
+                pres.CurrentQuarterroundIndexTextBox = (qrIndex - 1) % 4 + 1;
                 (int qrArrowIndex, int qrPrevArrowIndex) = calculateQRArrowIndex(qrIndex);
                 ((TextBox)GetIndexElement(pres, "ArrowQRRound", qrPrevArrowIndex)).Visibility = Visibility.Hidden;
                 ((TextBox)GetIndexElement(pres, "ArrowQRRound", qrArrowIndex)).Visibility = Visibility.Visible;
             }, () =>
             {
+                pres.CurrentQuarterroundIndexTextBox = (qrIndex - 2) % 4 + 1;
                 if (qrIndex > 1)
                 {
                     (int qrArrowIndex, int qrPrevArrowIndex) = calculateQRArrowIndex(qrIndex);

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -916,4 +916,12 @@ namespace Cryptool.Plugins.ChaCha
             return new PageAction[] { updateDescription, convert };
         }
     }
+
+    partial class Page
+    {
+        public static KeystreamBlockGenPage KeystreamBlockGenPage(ChaChaPresentation pres, ulong keyBlockNr)
+        {
+            return new KeystreamBlockGenPage(pres.UIKeystreamBlockGenPage, pres, keyBlockNr);
+        }
+    }
 }

--- a/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
+++ b/ChaCha/Visualization/Pages/KeystreamBlockGenPage.cs
@@ -741,7 +741,7 @@ namespace Cryptool.Plugins.ChaCha
         }
         public static string QuarterroundStartLabelWithRound(int qrIndex, int round)
         {
-            // Creates a label with quarterround indicator between 1-8.
+            // Creates a label with quarterround indicator between 1-4.
             // For example, the label for the beginning of third quarterround in the secound round: *PREFIX*_3_2
             return $"{ACTIONLABEL_QR_START}_{((qrIndex - 1) % 4) + 1}_{round}";
         }


### PR DESCRIPTION
Close #85

Created a navigation bar which enables user navigation to any keystream block, any round and any quarterround all via input textboxes.

Disposed of the navigation popup menu (#80) because popup menus are discouraged by the CT2 Team.

Furthermore, this navigation bar is much easier to grasp and does not take as much space as I thought one with similar features would (I have thought of creating designated buttons for each keystream page)

---

FIXME:
- [ ] Button "Keystream Generation" is not in bold when on pages for keystream generation